### PR TITLE
OGL-1136: missing default panel error

### DIFF
--- a/app/Providers/Filament/ArcheoPanelProvider.php
+++ b/app/Providers/Filament/ArcheoPanelProvider.php
@@ -30,6 +30,7 @@ class ArcheoPanelProvider extends PanelProvider
                 'primary' => Color::Cyan,
             ])
             ->login()
+            ->default()
             ->pages([
                 Dashboard::class,
             ])

--- a/app/Providers/Filament/EtnoPanelProvider.php
+++ b/app/Providers/Filament/EtnoPanelProvider.php
@@ -27,6 +27,7 @@ class EtnoPanelProvider extends PanelProvider
             ->id('etno')
             ->path('etno')
             ->login()
+            ->default()
             ->colors([
                 'primary' => Color::Amber,
             ])


### PR DESCRIPTION
Some default has to be set, otherwise commands like `filament:user` fail with:

```
No default Filament panel is set. You may do this with the `default()` method inside a Filament provider's `panel()` configuration.
```