### PR TITLE
fix(etno): validate document_overrides in item form

### DIFF
--- a/app-modules/etno/src/Filament/Resources/Items/Schemas/ItemForm.php
+++ b/app-modules/etno/src/Filament/Resources/Items/Schemas/ItemForm.php
@@ -4,7 +4,9 @@ namespace Metafori\Etno\Filament\Resources\Items\Schemas;
 
 use Filament\Forms\Components\Hidden;
 use Filament\Schemas\Schema;
+use Illuminate\Validation\Rule;
 use Metafori\Etno\Filament\Schemas\SharedMetadataSchema;
+use Metafori\Etno\Models\Item;
 
 class ItemForm
 {
@@ -13,7 +15,10 @@ class ItemForm
     public static function configure(Schema $schema): Schema
     {
         $components = self::components(inheritable: true);
-        $components[] = Hidden::make('document_overrides');
+        $components[] = Hidden::make('document_overrides')
+            ->rules(['array', Rule::in(Item::INHERITABLES)])
+            ->dehydrateStateUsing(fn ($state) => $state ?? [])
+            ->default([]);
 
         return $schema->components($components)
             ->columns(1);

--- a/app-modules/etno/tests/Feature/Filament/ItemResourceTest.php
+++ b/app-modules/etno/tests/Feature/Filament/ItemResourceTest.php
@@ -198,6 +198,56 @@ it('saves and overrides correctly for relational many fields', function (string 
         ->and($item->isInherited($column))->toBeFalse();
 })->with('inheritable_inputs_relational_many');
 
+it('validates and saves document_overrides correctly', function () {
+    $user = User::factory()->admin()->create();
+    $this->actingAs($user);
+
+    $document = Document::factory()->create();
+    $item = Item::factory()->create([
+        'document_id' => $document->id,
+    ]);
+
+    livewire(EditItem::class, [
+        'parentRecord' => $document,
+        'record' => $item->id,
+    ])
+        ->fillForm([
+            'document_overrides' => ['invalid_override_field'],
+        ])
+        ->call('save')
+        ->assertHasFormErrors(['document_overrides']);
+
+    livewire(EditItem::class, [
+        'parentRecord' => $document,
+        'record' => $item->id,
+    ])
+        ->fillForm([
+            'document_overrides' => [Item::INHERITABLES[0]],
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors(['document_overrides']);
+
+    livewire(EditItem::class, [
+        'parentRecord' => $document,
+        'record' => $item->id,
+    ])
+        ->fillForm([
+            'document_overrides' => null,
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors(['document_overrides']);
+
+    livewire(EditItem::class, [
+        'parentRecord' => $document,
+        'record' => $item->id,
+    ])
+        ->fillForm([
+            'document_overrides' => [],
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors(['document_overrides']);
+});
+
 dataset('inheritable_inputs_translatable', [
     'title' => ['title', ['en' => 'Parent Title EN', 'sk' => 'Parent Title SK'], ['en' => 'Overridden Title EN', 'sk' => 'Overridden Title SK']],
     'subtitle' => ['subtitle', ['en' => 'Parent Subtitle EN', 'sk' => 'Parent Subtitle SK'], ['en' => 'Overridden Subtitle EN', 'sk' => 'Overridden Subtitle SK']],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation for document override settings; only approved values accepted and null values are normalized to an empty list to prevent invalid configurations.

* **Tests**
  * Added test coverage confirming validation rejects invalid overrides, accepts approved values, and handles null/empty override inputs correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->