### PR TITLE
feat(etno): bulk media upload to one item

### DIFF
--- a/app-modules/core/src/Http/Resources/MediaResource.php
+++ b/app-modules/core/src/Http/Resources/MediaResource.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Metafori\Core\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+/**
+ * @mixin Media
+ */
+class MediaResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'file_name' => $this->file_name,
+            'human_readable_size' => $this->human_readable_size,
+            'mime_type' => $this->mime_type,
+            /** @var string */
+            'url' => $this->getTemporaryUrl(),
+            /** @var array<string, string> */
+            'conversions' => $this->getGeneratedConversions()
+                ->filter()
+                ->mapWithKeys(fn (true $hasGeneratedConversion, string $conversionName) => [
+                    $conversionName => $this->getTemporaryUrl(conversionName: $conversionName),
+                ]),
+        ];
+    }
+}

--- a/app-modules/etno/database/factories/ItemFactory.php
+++ b/app-modules/etno/database/factories/ItemFactory.php
@@ -3,6 +3,7 @@
 namespace Metafori\Etno\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Http\UploadedFile;
 use Metafori\Etno\Models\Document;
 use Metafori\Etno\Models\Item;
 
@@ -35,5 +36,23 @@ class ItemFactory extends Factory
         return $this->state([
             'document_overrides' => Item::INHERITABLES,
         ]);
+    }
+
+    public function withMedia(string $filename = 'document.pdf', array $customProperties = [], string $collection = 'documents', string $content = '%PDF-1.4'): static
+    {
+        return $this->afterCreating(function (Item $item) use ($filename, $customProperties, $collection, $content) {
+            $item->addMedia(UploadedFile::fake()->createWithContent($filename, $content))
+                ->withCustomProperties($customProperties)
+                ->toMediaCollection($collection);
+        });
+    }
+
+    public function withTranscribedMedia(
+        string $txt = 'text',
+        string $xml = '<?xml version="1.0" encoding="UTF-8"?>',
+        string $filename = 'document.pdf',
+        string $collection = 'documents'
+    ): static {
+        return $this->withMedia($filename, ['transcripts' => ['txt' => $txt, 'xml' => $xml]], $collection);
     }
 }

--- a/app-modules/etno/src/Enums/MediaType.php
+++ b/app-modules/etno/src/Enums/MediaType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Metafori\Etno\Enums;
+
+enum MediaType: string
+{
+    case Audio = 'audios';
+    case Document = 'documents';
+    case Image = 'images';
+    case Video = 'videos';
+}

--- a/app-modules/etno/src/Enums/TranscriptFormat.php
+++ b/app-modules/etno/src/Enums/TranscriptFormat.php
@@ -13,4 +13,17 @@ enum TranscriptFormat: string implements HasLabel
     {
         return strtoupper($this->value);
     }
+
+    public function getMimeType(): string
+    {
+        return match ($this) {
+            self::Xml => 'text/xml',
+            self::Txt => 'text/plain',
+        };
+    }
+
+    public static function mimeTypes(): array
+    {
+        return array_map(fn (self $format) => $format->getMimeType(), self::cases());
+    }
 }

--- a/app-modules/etno/src/Enums/TranscriptFormat.php
+++ b/app-modules/etno/src/Enums/TranscriptFormat.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Metafori\Etno\Enums;
+
+use Filament\Support\Contracts\HasLabel;
+
+enum TranscriptFormat: string implements HasLabel
+{
+    case Xml = 'xml';
+    case Txt = 'txt';
+
+    public function getLabel(): string
+    {
+        return strtoupper($this->value);
+    }
+}

--- a/app-modules/etno/src/Filament/Actions/Items/RegenerateIds.php
+++ b/app-modules/etno/src/Filament/Actions/Items/RegenerateIds.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Metafori\Etno\Filament\Actions\Items;
+
+use Filament\Actions\Action;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
+use Filament\Support\Icons\Heroicon;
+use Metafori\Etno\Filament\Contracts\HasDocument;
+use Metafori\Etno\Models\Document;
+
+class RegenerateIds extends Action
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->label('Regenerate IDs')
+            ->icon(Heroicon::ArrowPath)
+            ->visible(fn (Get $get) => ! empty($get->array('items')))
+            ->action($this->regenerateIds(...));
+    }
+
+    public function regenerateIds(Get $get, Set $set, HasDocument $livewire): void
+    {
+        $items = $get->array('items');
+        $suffix = $livewire->getDocument()
+            ->generateNextSequenceSuffix();
+
+        foreach (array_keys($items) as $key) {
+            $items[$key]['suffix'] = $suffix;
+            $suffix = Document::incrementSuffix($suffix);
+        }
+
+        $set('items', $items);
+    }
+}

--- a/app-modules/etno/src/Filament/Actions/Items/UploadMediaAction.php
+++ b/app-modules/etno/src/Filament/Actions/Items/UploadMediaAction.php
@@ -32,6 +32,11 @@ class UploadMediaAction extends Action
                     ->previewable(false)
                     ->multiple()
                     ->live()
+                    ->acceptedFileTypes(fn (Item $record) => [
+                        ...$record->allowedMediaMimeTypes(),
+                        'text/plain',
+                        'text/xml',
+                    ])
                     ->afterStateUpdated(function (array $state, Set $set, Get $get) {
                         $media = $get->array('media');
                         $transcripts = $get->array('transcripts');
@@ -61,13 +66,14 @@ class UploadMediaAction extends Action
 
                 MediaRepeater::make('media')
                     ->rule(fn (Item $record) => function (string $attribute, $value, Closure $fail) use ($record) {
-                        $mimeTypes = $record->getMedia()
+                        $mediaTypes = $record->media
                             ->pluck('mime_type')
                             ->merge(collect($value)->pluck('file')->map->getMimeType())
+                            ->map(Item::getMediaCollectionName(...))
                             ->unique();
 
-                        if ($mimeTypes->count() > 1) {
-                            $fail("The mime type of the file must match the other item's media files.");
+                        if ($mediaTypes->count() > 1) {
+                            $fail("The media type of the file must match the other item's media files.");
                         }
                     }),
             ])

--- a/app-modules/etno/src/Filament/Actions/Items/UploadMediaAction.php
+++ b/app-modules/etno/src/Filament/Actions/Items/UploadMediaAction.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Metafori\Etno\Filament\Actions\Items;
+
+use Closure;
+use Filament\Actions\Action;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Hidden;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Support\Facades\File;
+use Livewire\Features\SupportFileUploads\FileUploadConfiguration;
+use Metafori\Etno\Filament\Concerns\HandlesMediaUploads;
+use Metafori\Etno\Filament\Forms\Components\Items\MediaRepeater;
+use Metafori\Etno\Filament\Resources\Items\ItemResource;
+use Metafori\Etno\Models\Item;
+
+class UploadMediaAction extends Action
+{
+    use HandlesMediaUploads;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->label('Upload Media')
+            ->icon(Heroicon::OutlinedArrowUpTray)
+            ->form([
+                FileUpload::make('files')
+                    ->maxParallelUploads(6)
+                    ->disableLabel()
+                    ->storeFiles(false)
+                    ->previewable(false)
+                    ->multiple()
+                    ->live()
+                    ->afterStateUpdated(function (array $state, Set $set, Get $get) {
+                        $media = collect($get->array('media'));
+                        $transcripts = $get->array('transcripts');
+
+                        [$transcripts, $mediaFiles] = $this->extractTranscripts($state, $transcripts);
+
+                        $this->syncMedia($mediaFiles, $media);
+                        $this->applyTranscriptsToMedia($media, $transcripts);
+
+                        $set('transcripts', $transcripts);
+                        $set('media', $media->toArray());
+                    }),
+
+                Hidden::make('transcripts')
+                    ->default([]),
+
+                MediaRepeater::make('media')
+                    ->rule(fn (Item $record) => function (string $attribute, $value, Closure $fail) use ($record) {
+                        $mimeTypes = $record->getMedia()
+                            ->pluck('mime_type')
+                            ->merge(collect($value)->pluck('file')->map->getMimeType())
+                            ->unique();
+
+                        if ($mimeTypes->count() > 1) {
+                            $fail("The mime type of the file must match the other item's media files.");
+                        }
+                    }),
+            ])
+            ->action(function (array $data, Item $record): void {
+                foreach ($data['media'] ?? [] as $media) {
+                    $record->addMediaFromDisk($media['file']->getClientOriginalPath(), FileUploadConfiguration::disk())
+                        ->usingName(File::name($media['file']->getClientOriginalName()))
+                        ->usingFileName($media['file']->getClientOriginalName())
+                        ->withCustomProperties($media['custom_properties'] ?? [])
+                        ->toMediaCollection();
+                }
+
+                $this->redirect(ItemResource::getUrl('edit', [
+                    'document' => $record->document,
+                    'record' => $record->id,
+                    'relation' => 'media',
+                ]));
+            });
+    }
+}

--- a/app-modules/etno/src/Filament/Actions/Items/UploadMediaAction.php
+++ b/app-modules/etno/src/Filament/Actions/Items/UploadMediaAction.php
@@ -45,6 +45,17 @@ class UploadMediaAction extends Action
 
                         $set('transcripts', $transcripts);
                         $set('media', $media->toArray());
+                    })
+                    ->rule(fn (Get $get) => function (string $attribute, $value, Closure $fail) use ($get) {
+                        $files = $get->array('files') ?? [];
+
+                        [$transcripts, $mediaFiles] = collect($files)
+                            ->partition($this->isTranscript(...))
+                            ->all();
+
+                        if ($mediaFiles->isEmpty() && $transcripts->isNotEmpty()) {
+                            $fail('Cannot upload transcripts without corresponding media files.');
+                        }
                     }),
 
                 Hidden::make('transcripts')

--- a/app-modules/etno/src/Filament/Actions/Items/UploadMediaAction.php
+++ b/app-modules/etno/src/Filament/Actions/Items/UploadMediaAction.php
@@ -9,8 +9,6 @@ use Filament\Forms\Components\Hidden;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Support\Icons\Heroicon;
-use Illuminate\Support\Facades\File;
-use Livewire\Features\SupportFileUploads\FileUploadConfiguration;
 use Metafori\Etno\Filament\Concerns\HandlesMediaUploads;
 use Metafori\Etno\Filament\Forms\Components\Items\MediaRepeater;
 use Metafori\Etno\Filament\Resources\Items\ItemResource;
@@ -35,16 +33,16 @@ class UploadMediaAction extends Action
                     ->multiple()
                     ->live()
                     ->afterStateUpdated(function (array $state, Set $set, Get $get) {
-                        $media = collect($get->array('media'));
+                        $media = $get->array('media');
                         $transcripts = $get->array('transcripts');
 
                         [$transcripts, $mediaFiles] = $this->extractTranscripts($state, $transcripts);
 
-                        $this->syncMedia($mediaFiles, $media);
-                        $this->applyTranscriptsToMedia($media, $transcripts);
+                        $media = $this->syncMedia($mediaFiles, $media);
+                        $media = $this->applyTranscriptsToMedia($media, $transcripts);
 
                         $set('transcripts', $transcripts);
-                        $set('media', $media->toArray());
+                        $set('media', $media);
                     })
                     ->rule(fn (Get $get) => function (string $attribute, $value, Closure $fail) use ($get) {
                         $files = $get->array('files') ?? [];
@@ -75,11 +73,7 @@ class UploadMediaAction extends Action
             ])
             ->action(function (array $data, Item $record): void {
                 foreach ($data['media'] ?? [] as $media) {
-                    $record->addMediaFromDisk($media['file']->getClientOriginalPath(), FileUploadConfiguration::disk())
-                        ->usingName(File::name($media['file']->getClientOriginalName()))
-                        ->usingFileName($media['file']->getClientOriginalName())
-                        ->withCustomProperties($media['custom_properties'] ?? [])
-                        ->toMediaCollection();
+                    $this->addItemMedia($record, $media['file'], $media['custom_properties']);
                 }
 
                 $this->redirect(ItemResource::getUrl('edit', [

--- a/app-modules/etno/src/Filament/Actions/Items/UploadMediaAction.php
+++ b/app-modules/etno/src/Filament/Actions/Items/UploadMediaAction.php
@@ -9,6 +9,7 @@ use Filament\Forms\Components\Hidden;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Support\Icons\Heroicon;
+use Metafori\Etno\Enums\TranscriptFormat;
 use Metafori\Etno\Filament\Concerns\HandlesMediaUploads;
 use Metafori\Etno\Filament\Forms\Components\Items\MediaRepeater;
 use Metafori\Etno\Filament\Resources\Items\ItemResource;
@@ -27,15 +28,14 @@ class UploadMediaAction extends Action
             ->form([
                 FileUpload::make('files')
                     ->maxParallelUploads(6)
-                    ->disableLabel()
+                    ->hiddenLabel()
                     ->storeFiles(false)
                     ->previewable(false)
                     ->multiple()
                     ->live()
                     ->acceptedFileTypes(fn (Item $record) => [
                         ...$record->allowedMediaMimeTypes(),
-                        'text/plain',
-                        'text/xml',
+                        ...TranscriptFormat::mimeTypes(),
                     ])
                     ->afterStateUpdated(function (array $state, Set $set, Get $get) {
                         $media = $get->array('media');

--- a/app-modules/etno/src/Filament/Concerns/HandlesMediaUploads.php
+++ b/app-modules/etno/src/Filament/Concerns/HandlesMediaUploads.php
@@ -2,14 +2,17 @@
 
 namespace Metafori\Etno\Filament\Concerns;
 
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Livewire\Features\SupportFileUploads\FileUploadConfiguration;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Metafori\Etno\Enums\TranscriptFormat;
+use Metafori\Etno\Models\Item;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 trait HandlesMediaUploads
 {
-    protected function extractTranscripts(array $files, array $transcripts): array
+    protected function extractTranscripts(array $files, array $transcripts = []): array
     {
         [$transcriptFiles, $mediaFiles] = collect($files)
             ->partition($this->isTranscript(...))
@@ -21,23 +24,24 @@ trait HandlesMediaUploads
             $transcripts[$basename][$format->value] ??= $file->get();
         }
 
-        return [$transcripts, $mediaFiles];
+        return [$transcripts, $mediaFiles->toArray()];
     }
 
-    protected function syncMedia(Collection $files, Collection $media): void
+    protected function syncMedia(array $files, array $media): array
     {
-        $removedKeys = $media
-            ->reject(fn ($medium) => $files->contains($medium['file']))
-            ->keys();
+        $media = array_filter($media, fn ($medium) => \in_array($medium['file'], $files, strict: false));
 
-        $media->forget($removedKeys);
+        $mediaFiles = array_column($media, 'file');
+        foreach ($files as $file) {
+            if (! \in_array($file, $mediaFiles, strict: false)) {
+                $media[(string) Str::uuid()] = [
+                    'file' => $file,
+                    'custom_properties' => [],
+                ];
+            }
+        }
 
-        $files
-            ->reject(fn ($file) => $media->contains('file', $file))
-            ->each(fn ($file) => $media->push([
-                'file' => $file,
-                'custom_properties' => [],
-            ]));
+        return $media;
     }
 
     protected function getTranscriptFormat(TemporaryUploadedFile $file): ?TranscriptFormat
@@ -52,20 +56,34 @@ trait HandlesMediaUploads
         return $this->getTranscriptFormat($file) !== null;
     }
 
-    protected function applyTranscriptsToMedia(Collection $media, array $transcripts): void
+    protected function applyTranscriptsToMedium(array $medium, array $transcripts): array
     {
-        $media
-            ->transform(function ($medium) use ($transcripts) {
-                $file = $medium['file'];
-                $basename = File::name($file->getClientOriginalName());
+        $basename = File::name($medium['file']->getClientOriginalName());
 
-                foreach (TranscriptFormat::cases() as $format) {
-                    if (isset($transcripts[$basename][$format->value])) {
-                        $medium['custom_properties']['transcripts'][$format->value] ??= $transcripts[$basename][$format->value];
-                    }
-                }
+        foreach (TranscriptFormat::cases() as $format) {
+            if (isset($transcripts[$basename][$format->value])) {
+                $medium['custom_properties']['transcripts'][$format->value] ??= $transcripts[$basename][$format->value];
+            }
+        }
 
-                return $medium;
-            });
+        return $medium;
+    }
+
+    protected function applyTranscriptsToMedia(array $media, array $transcripts): array
+    {
+        foreach ($media as &$medium) {
+            $medium = $this->applyTranscriptsToMedium($medium, $transcripts);
+        }
+
+        return $media;
+    }
+
+    protected function addItemMedia(Item $item, TemporaryUploadedFile $file, array $customProperties): Media
+    {
+        return $item->addMediaFromDisk($file->getClientOriginalPath(), FileUploadConfiguration::disk())
+            ->usingName(File::name($file->getClientOriginalName()))
+            ->usingFileName($file->getClientOriginalName())
+            ->withCustomProperties($customProperties)
+            ->toMediaCollection();
     }
 }

--- a/app-modules/etno/src/Filament/Concerns/HandlesMediaUploads.php
+++ b/app-modules/etno/src/Filament/Concerns/HandlesMediaUploads.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Metafori\Etno\Filament\Concerns;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+use Metafori\Etno\Enums\TranscriptFormat;
+
+trait HandlesMediaUploads
+{
+    protected function extractTranscripts(array $files, array $transcripts): array
+    {
+        [$transcriptFiles, $mediaFiles] = collect($files)
+            ->partition($this->isTranscript(...))
+            ->all();
+
+        foreach ($transcriptFiles as $file) {
+            $format = $this->getTranscriptFormat($file);
+            $basename = File::name($file->getClientOriginalName());
+            $transcripts[$basename][$format->value] ??= $file->get();
+        }
+
+        return [$transcripts, $mediaFiles];
+    }
+
+    protected function syncMedia(Collection $files, Collection $media): void
+    {
+        $removedKeys = $media
+            ->reject(fn ($medium) => $files->contains($medium['file']))
+            ->keys();
+
+        $media->forget($removedKeys);
+
+        $files
+            ->reject(fn ($file) => $media->contains('file', $file))
+            ->each(fn ($file) => $media->push([
+                'file' => $file,
+                'custom_properties' => [],
+            ]));
+    }
+
+    protected function getTranscriptFormat(TemporaryUploadedFile $file): ?TranscriptFormat
+    {
+        $type = strtolower($file->getClientOriginalExtension());
+
+        return TranscriptFormat::tryFrom($type);
+    }
+
+    protected function isTranscript(TemporaryUploadedFile $file): bool
+    {
+        return $this->getTranscriptFormat($file) !== null;
+    }
+
+    protected function applyTranscriptsToMedia(Collection $media, array $transcripts): void
+    {
+        $media
+            ->transform(function ($medium) use ($transcripts) {
+                $file = $medium['file'];
+                $basename = File::name($file->getClientOriginalName());
+
+                foreach (TranscriptFormat::cases() as $format) {
+                    if (isset($transcripts[$basename][$format->value])) {
+                        $medium['custom_properties']['transcripts'][$format->value] ??= $transcripts[$basename][$format->value];
+                    }
+                }
+
+                return $medium;
+            });
+    }
+}

--- a/app-modules/etno/src/Filament/Concerns/HandlesMediaUploads.php
+++ b/app-modules/etno/src/Filament/Concerns/HandlesMediaUploads.php
@@ -78,6 +78,15 @@ trait HandlesMediaUploads
         return $media;
     }
 
+    protected function applyTranscriptsToItems(array $items, array $transcripts): array
+    {
+        foreach ($items as $uuid => $item) {
+            $items[$uuid]['media'] = $this->applyTranscriptsToMedium($item['media'], $transcripts);
+        }
+
+        return $items;
+    }
+
     protected function addItemMedia(Item $item, TemporaryUploadedFile $file, array $customProperties): Media
     {
         $collection = Item::getMediaCollectionName($file->getMimeType()) ?? throw new \InvalidArgumentException("Unsupported mime type: {$file->getMimeType()}");

--- a/app-modules/etno/src/Filament/Concerns/HandlesMediaUploads.php
+++ b/app-modules/etno/src/Filament/Concerns/HandlesMediaUploads.php
@@ -80,10 +80,12 @@ trait HandlesMediaUploads
 
     protected function addItemMedia(Item $item, TemporaryUploadedFile $file, array $customProperties): Media
     {
+        $collection = Item::getMediaCollectionName($file->getMimeType()) ?? throw new \InvalidArgumentException("Unsupported mime type: {$file->getMimeType()}");
+
         return $item->addMediaFromDisk($file->getClientOriginalPath(), FileUploadConfiguration::disk())
             ->usingName(File::name($file->getClientOriginalName()))
             ->usingFileName($file->getClientOriginalName())
             ->withCustomProperties($customProperties)
-            ->toMediaCollection();
+            ->toMediaCollection($collection);
     }
 }

--- a/app-modules/etno/src/Filament/Concerns/WithDocument.php
+++ b/app-modules/etno/src/Filament/Concerns/WithDocument.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Metafori\Etno\Filament\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+use Metafori\Etno\Models\Document;
+use Metafori\Etno\Models\Item;
+
+trait WithDocument
+{
+    public function getDocument(): Document
+    {
+        if (
+            isset($this->record)
+            && ($document = $this->extractDocumentFromRecord($this->record))
+        ) {
+            return $document;
+        }
+
+        if (
+            method_exists($this, 'getOwnerRecord')
+            && ($record = $this->getOwnerRecord())
+            && ($document = $this->extractDocumentFromRecord($record))
+        ) {
+            return $document;
+        }
+
+        if (
+            method_exists($this, 'getParentRecord')
+            && ($record = $this->getParentRecord())
+            && ($document = $this->extractDocumentFromRecord($record))
+        ) {
+            return $document;
+        }
+
+        throw new \LogicException('Unable to resolve Document from record, owner record, or parent record.');
+    }
+
+    protected function extractDocumentFromRecord(Model $record): ?Document
+    {
+        if ($record instanceof Document) {
+            return $record;
+        }
+
+        if ($record instanceof Item) {
+            return $record->document;
+        }
+
+        return null;
+    }
+}

--- a/app-modules/etno/src/Filament/Contracts/HasDocument.php
+++ b/app-modules/etno/src/Filament/Contracts/HasDocument.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Metafori\Etno\Filament\Contracts;
+
+use Metafori\Etno\Models\Document;
+
+interface HasDocument
+{
+    public function getDocument(): Document;
+}

--- a/app-modules/etno/src/Filament/Forms/Components/Items/ItemsFromFilesRepeater.php
+++ b/app-modules/etno/src/Filament/Forms/Components/Items/ItemsFromFilesRepeater.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Metafori\Etno\Filament\Forms\Components\Items;
+
+use Filament\Actions\Action;
+use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Repeater\TableColumn;
+use Filament\Schemas\Components\Section;
+use Filament\Support\Icons\Heroicon;
+use Metafori\Etno\Enums\TranscriptFormat;
+use Metafori\Etno\Filament\Forms\Components\SuffixInput;
+use Metafori\Etno\Filament\Resources\Items\Schemas\MediaForm;
+
+class ItemsFromFilesRepeater extends Repeater
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $transcriptActions = array_map(
+            fn (TranscriptFormat $format) => Action::make("has_{$format->value}")
+                ->tooltip("{$format->getLabel()} Transcript Attached")
+                ->icon(Heroicon::CheckCircle)
+                ->color('primary')
+                ->disabled()
+                ->hidden(fn (array $arguments, self $component): bool => ! $this->hasTranscript($format, $arguments['item'], $component)),
+            TranscriptFormat::cases()
+        );
+
+        $this
+            ->extraItemActions($transcriptActions)
+            ->table([
+                TableColumn::make('New Item ID')
+                    ->markAsRequired(),
+                TableColumn::make('Media Files')
+                    ->width('80%'),
+            ])
+            ->compact()
+            ->schema([
+                SuffixInput::make('suffix')
+                    ->distinct(),
+
+                Section::make(fn ($state) => $state['file']->getClientOriginalName())
+                    ->schema([
+                        Hidden::make('file'),
+                        ...MediaForm::transcriptFields(),
+                    ])
+                    ->statePath('media')
+                    ->columns(2)
+                    ->collapsible()
+                    ->collapsed(),
+            ])
+            ->hiddenLabel()
+            ->collapsible()
+            ->collapsed()
+            ->addable(false)
+            ->reorderableWithDragAndDrop();
+    }
+
+    public function hasTranscript(TranscriptFormat $format, string $item, self $component): bool
+    {
+        $state = $component->getState()[$item] ?? [];
+
+        return isset($state['media']['custom_properties']['transcripts'][$format->value]);
+    }
+}

--- a/app-modules/etno/src/Filament/Forms/Components/Items/MediaRepeater.php
+++ b/app-modules/etno/src/Filament/Forms/Components/Items/MediaRepeater.php
@@ -20,6 +20,7 @@ class MediaRepeater extends Repeater
                 fn (TranscriptFormat $format) => Action::make("has_{$format->value}")
                     ->tooltip("{$format->getLabel()} Transcript Attached")
                     ->icon(Heroicon::CheckCircle)
+                    ->color('primary')
                     ->disabled(true)
                     ->hidden(fn (array $arguments, self $component): bool => ! $this->hasTranscript($format, $arguments['item'], $component))
             );
@@ -45,7 +46,7 @@ class MediaRepeater extends Repeater
             })
             ->schema([
                 \Filament\Forms\Components\Hidden::make('file'),
-                ...MediaForm::transcriptionFields(),
+                ...MediaForm::transcriptFields(),
             ])
             ->columns(2)
             ->disableLabel()
@@ -55,7 +56,6 @@ class MediaRepeater extends Repeater
             ->defaultItems(0)
             ->addable(false)
             ->reorderableWithDragAndDrop()
-            ->reorderableWithButtons()
             ->hintAction(
                 Action::make('order_by_name')
                     ->hidden(fn (array $state) => \count($state ?? []) < 2)

--- a/app-modules/etno/src/Filament/Forms/Components/Items/MediaRepeater.php
+++ b/app-modules/etno/src/Filament/Forms/Components/Items/MediaRepeater.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Metafori\Etno\Filament\Forms\Components\Items;
+
+use Closure;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Repeater;
+use Filament\Support\Icons\Heroicon;
+use Metafori\Etno\Enums\TranscriptFormat;
+use Metafori\Etno\Filament\Resources\Items\Schemas\MediaForm;
+
+class MediaRepeater extends Repeater
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $transcriptActions = collect(TranscriptFormat::cases())
+            ->map(
+                fn (TranscriptFormat $format) => Action::make("has_{$format->value}")
+                    ->tooltip("{$format->getLabel()} Transcript Attached")
+                    ->icon(Heroicon::CheckCircle)
+                    ->disabled(true)
+                    ->hidden(fn (array $arguments, self $component): bool => ! $this->hasTranscript($format, $arguments['item'], $component))
+            );
+
+        $this->extraItemActions([
+            ...$transcriptActions,
+            Action::make('toggle_details')
+                ->label('Transcript')
+                ->icon(Heroicon::PencilSquare)
+                ->link()
+                ->color('gray')
+                ->alpineClickHandler('isCollapsed = !isCollapsed'),
+        ])
+            ->rule(fn () => function (string $attribute, $value, Closure $fail) {
+                $mimeTypes = collect($value)
+                    ->pluck('file')
+                    ->map->getMimeType()
+                    ->unique();
+
+                if ($mimeTypes->count() > 1) {
+                    $fail('The mime type of the file must match the other media files.');
+                }
+            })
+            ->schema([
+                \Filament\Forms\Components\Hidden::make('file'),
+                ...MediaForm::transcriptionFields(),
+            ])
+            ->columns(2)
+            ->disableLabel()
+            ->itemLabel(fn (array $state) => $state['file']->getClientOriginalName())
+            ->collapsible()
+            ->collapsed(true)
+            ->defaultItems(0)
+            ->addable(false)
+            ->reorderableWithDragAndDrop()
+            ->reorderableWithButtons()
+            ->hintAction(
+                Action::make('order_by_name')
+                    ->hidden(fn (array $state) => \count($state ?? []) < 2)
+                    ->label('Order by Name')
+                    ->icon(Heroicon::BarsArrowDown)
+                    ->action(function (self $component) {
+                        $state = $component->getState();
+                        uasort($state, fn ($a, $b) => strnatcasecmp(
+                            $a['file']->getClientOriginalName(),
+                            $b['file']->getClientOriginalName()
+                        ));
+                        $component->state($state);
+                    })
+            );
+    }
+
+    public function hasTranscript(TranscriptFormat $format, string $item, Repeater $component): bool
+    {
+        $state = $component->getState()[$item] ?? [];
+
+        return isset($state['custom_properties']['transcripts'][$format->value]);
+    }
+}

--- a/app-modules/etno/src/Filament/Forms/Components/Items/MediaRepeater.php
+++ b/app-modules/etno/src/Filament/Forms/Components/Items/MediaRepeater.php
@@ -8,6 +8,7 @@ use Filament\Forms\Components\Repeater;
 use Filament\Support\Icons\Heroicon;
 use Metafori\Etno\Enums\TranscriptFormat;
 use Metafori\Etno\Filament\Resources\Items\Schemas\MediaForm;
+use Metafori\Etno\Models\Item;
 
 class MediaRepeater extends Repeater
 {
@@ -35,13 +36,14 @@ class MediaRepeater extends Repeater
                 ->alpineClickHandler('isCollapsed = !isCollapsed'),
         ])
             ->rule(fn () => function (string $attribute, $value, Closure $fail) {
-                $mimeTypes = collect($value)
+                $mediaTypes = collect($value)
                     ->pluck('file')
                     ->map->getMimeType()
+                    ->map(Item::getMediaCollectionName(...))
                     ->unique();
 
-                if ($mimeTypes->count() > 1) {
-                    $fail('The mime type of the file must match the other media files.');
+                if ($mediaTypes->count() > 1) {
+                    $fail('The media type of the file must match the other media files.');
                 }
             })
             ->schema([

--- a/app-modules/etno/src/Filament/Forms/Components/Items/TranscriptTextarea.php
+++ b/app-modules/etno/src/Filament/Forms/Components/Items/TranscriptTextarea.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Metafori\Etno\Filament\Forms\Components\Items;
+
+use Filament\Forms\Components\Textarea;
+
+class TranscriptTextarea extends Textarea
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $dropzoneJs = <<<'JS'
+            let file = $event.dataTransfer.files[0];
+            if (!file) return;
+            let reader = new FileReader();
+            reader.onload = (e) => {
+                $el.value = e.target.result;
+                $el.dispatchEvent(new Event('input', { bubbles: true }));
+                $el.dispatchEvent(new Event('change', { bubbles: true }));
+                $el.dispatchEvent(new Event('blur', { bubbles: true }));
+            };
+            reader.readAsText(file);
+        JS;
+
+        $dropzoneAttributes = [
+            'x-on:drop.prevent' => $dropzoneJs,
+        ];
+
+        $this->rows(8)
+            ->live(onBlur: true)
+            ->extraInputAttributes($dropzoneAttributes);
+    }
+}

--- a/app-modules/etno/src/Filament/Forms/Components/Items/TranscriptTextarea.php
+++ b/app-modules/etno/src/Filament/Forms/Components/Items/TranscriptTextarea.php
@@ -25,6 +25,7 @@ class TranscriptTextarea extends Textarea
 
         $dropzoneAttributes = [
             'x-on:drop.prevent' => $dropzoneJs,
+            'x-on:dragover.prevent' => '',
         ];
 
         $this->rows(8)

--- a/app-modules/etno/src/Filament/Forms/Components/SuffixInput.php
+++ b/app-modules/etno/src/Filament/Forms/Components/SuffixInput.php
@@ -4,7 +4,7 @@ namespace Metafori\Etno\Filament\Forms\Components;
 
 use Filament\Forms\Components\TextInput;
 use Illuminate\Validation\Rules\Unique;
-use Livewire\Component;
+use Metafori\Etno\Filament\Contracts\HasDocument;
 
 class SuffixInput extends TextInput
 {
@@ -13,12 +13,12 @@ class SuffixInput extends TextInput
         parent::setUp();
 
         $this->label('Composite ID')
-            ->prefix(fn (Component $livewire) => $livewire->parentRecord?->id)
+            ->prefix(fn (HasDocument $livewire) => $livewire->getDocument()->id)
             ->required()
             ->unique(
                 ignoreRecord: true,
-                modifyRuleUsing: fn (Unique $rule, Component $livewire) => $rule
-                    ->where('document_id', $livewire->parentRecord?->id)
+                modifyRuleUsing: fn (Unique $rule, HasDocument $livewire) => $rule
+                    ->where('document_id', $livewire->getDocument()->id)
                     ->withoutTrashed()
             )
             ->maxLength(255);

--- a/app-modules/etno/src/Filament/Resources/Documents/DocumentResource.php
+++ b/app-modules/etno/src/Filament/Resources/Documents/DocumentResource.php
@@ -22,6 +22,8 @@ class DocumentResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedDocumentText;
 
+    protected static ?string $recordTitleAttribute = 'id';
+
     public static function form(Schema $schema): Schema
     {
         return DocumentForm::configure($schema);

--- a/app-modules/etno/src/Filament/Resources/Documents/RelationManagers/ItemsRelationManager.php
+++ b/app-modules/etno/src/Filament/Resources/Documents/RelationManagers/ItemsRelationManager.php
@@ -2,7 +2,10 @@
 
 namespace Metafori\Etno\Filament\Resources\Documents\RelationManagers;
 
+use Filament\Actions\Action;
+use Filament\Actions\CreateAction;
 use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
@@ -22,7 +25,14 @@ class ItemsRelationManager extends RelationManager
                 SoftDeletingScope::class,
             ]))
             ->headerActions([
-                \Filament\Actions\CreateAction::make(),
+                CreateAction::make(),
+                Action::make('create_from_files')
+                    ->label('Create from files')
+                    ->icon(Heroicon::OutlinedDocumentArrowUp)
+                    ->url(fn (RelationManager $livewire): string => ItemResource::getUrl(
+                        'create-from-files',
+                        ['document' => $livewire->getOwnerRecord()]
+                    )),
             ]);
     }
 }

--- a/app-modules/etno/src/Filament/Resources/Items/ItemResource.php
+++ b/app-modules/etno/src/Filament/Resources/Items/ItemResource.php
@@ -45,6 +45,13 @@ class ItemResource extends Resource
         return ItemsTable::configure($table);
     }
 
+    public static function getRelations(): array
+    {
+        return [
+            'media' => RelationManagers\MediaRelationManager::class,
+        ];
+    }
+
     public static function getPages(): array
     {
         return [

--- a/app-modules/etno/src/Filament/Resources/Items/ItemResource.php
+++ b/app-modules/etno/src/Filament/Resources/Items/ItemResource.php
@@ -16,6 +16,8 @@ class ItemResource extends Resource
 {
     protected static ?string $model = Item::class;
 
+    protected static ?string $recordTitleAttribute = 'identifier';
+
     public static function getEloquentQuery(): Builder
     {
         return parent::getEloquentQuery()
@@ -57,6 +59,7 @@ class ItemResource extends Resource
         return [
             'create' => Pages\CreateItem::route('/create'),
             'edit' => Pages\EditItem::route('/{record}/edit'),
+            'create-from-files' => Pages\CreateItemsFromFiles::route('/create-from-files'),
         ];
     }
 }

--- a/app-modules/etno/src/Filament/Resources/Items/Pages/CreateItem.php
+++ b/app-modules/etno/src/Filament/Resources/Items/Pages/CreateItem.php
@@ -3,10 +3,14 @@
 namespace Metafori\Etno\Filament\Resources\Items\Pages;
 
 use Filament\Resources\Pages\CreateRecord;
+use Metafori\Etno\Filament\Concerns\WithDocument;
+use Metafori\Etno\Filament\Contracts\HasDocument;
 use Metafori\Etno\Filament\Resources\Items\ItemResource;
 
-class CreateItem extends CreateRecord
+class CreateItem extends CreateRecord implements HasDocument
 {
+    use WithDocument;
+
     protected static string $resource = ItemResource::class;
 
     protected function getHeaderActions(): array

--- a/app-modules/etno/src/Filament/Resources/Items/Pages/CreateItemsFromFiles.php
+++ b/app-modules/etno/src/Filament/Resources/Items/Pages/CreateItemsFromFiles.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Metafori\Etno\Filament\Resources\Items\Pages;
+
+use Filament\Actions\Action;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Hidden;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Resources\Pages\Page;
+use Filament\Schemas\Components\EmbeddedSchema;
+use Filament\Schemas\Components\Form;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
+use Filament\Schemas\Components\Wizard;
+use Filament\Schemas\Components\Wizard\Step;
+use Filament\Schemas\Schema;
+use Metafori\Etno\Enums\TranscriptFormat;
+use Metafori\Etno\Filament\Actions\Items\RegenerateIds;
+use Metafori\Etno\Filament\Concerns\HandlesMediaUploads;
+use Metafori\Etno\Filament\Concerns\WithDocument;
+use Metafori\Etno\Filament\Contracts\HasDocument;
+use Metafori\Etno\Filament\Forms\Components\Items\ItemsFromFilesRepeater;
+use Metafori\Etno\Filament\Resources\Documents\DocumentResource;
+use Metafori\Etno\Filament\Resources\Items\ItemResource;
+use Metafori\Etno\Models\Document;
+use Metafori\Etno\Models\Item;
+
+class CreateItemsFromFiles extends Page implements HasDocument, HasForms
+{
+    use HandlesMediaUploads;
+    use InteractsWithForms;
+    use WithDocument;
+
+    protected static string $resource = ItemResource::class;
+
+    protected static ?string $breadcrumb = 'Create From Files';
+
+    public ?array $data = [];
+
+    public function form(Schema $form): Schema
+    {
+        return $form
+            ->components([
+                Wizard::make([
+                    Step::make('Upload Files')
+                        ->schema([
+                            FileUpload::make('files')
+                                ->acceptedFileTypes([
+                                    ...(new Item)->allowedMediaMimeTypes(),
+                                    ...TranscriptFormat::mimeTypes(),
+                                ])
+                                ->required()
+                                ->previewable(false)
+                                ->multiple()
+                                ->hiddenLabel()
+                                ->storeFiles(false),
+                        ])
+                        ->afterValidation(function (Set $set, Get $get) {
+                            $files = $get->array('files');
+                            $suffix = $this->getDocument()
+                                ->generateNextSequenceSuffix();
+
+                            [$transcripts, $mediaFiles] = $this->extractTranscripts($files);
+                            $items = $this->syncItems($mediaFiles, $suffix);
+                            $items = $this->applyTranscriptsToItems($items, $transcripts);
+
+                            $set('items', $items);
+                        }),
+                    Step::make('Review & Rearrange')
+                        ->schema([
+                            RegenerateIds::make('regenerate_ids'),
+                            ItemsFromFilesRepeater::make('items'),
+                            Hidden::make('transcripts')
+                                ->default([]),
+                        ]),
+                ])
+                    ->submitAction(
+                        Action::make('create')
+                            ->label('Create Items')
+                            ->submit('createFromFiles')
+                    ),
+            ])
+            ->statePath('data');
+    }
+
+    public function content(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Form::make([
+                    EmbeddedSchema::make('form'),
+                ])
+                    ->id('form')
+                    ->livewireSubmitHandler('createFromFiles'),
+            ]);
+    }
+
+    protected function syncItems($files, string $suffix): array
+    {
+        $items = [];
+        foreach ($files as $uuid => $file) {
+            $items[$uuid] = [
+                'suffix' => $suffix,
+                'media' => [
+                    'file' => $file,
+                    'custom_properties' => [],
+                ],
+            ];
+
+            $suffix = Document::incrementSuffix($suffix);
+        }
+
+        return $items;
+    }
+
+    public function createFromFiles(): void
+    {
+        $data = $this->form->getState();
+        $items = $this->getDocument()->items();
+
+        foreach ($data['items'] as $itemData) {
+            $createdItem = $items->create(['suffix' => $itemData['suffix']]);
+            $this->addItemMedia($createdItem, $itemData['media']['file'], $itemData['media']['custom_properties'] ?? []);
+        }
+
+        $this->redirect(DocumentResource::getUrl('edit', [
+            'record' => $this->getParentRecord(),
+            'relation' => 'items',
+        ]));
+    }
+}

--- a/app-modules/etno/src/Filament/Resources/Items/Pages/EditItem.php
+++ b/app-modules/etno/src/Filament/Resources/Items/Pages/EditItem.php
@@ -5,10 +5,14 @@ namespace Metafori\Etno\Filament\Resources\Items\Pages;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
 use Metafori\Etno\Filament\Actions\Items\UploadMediaAction;
+use Metafori\Etno\Filament\Concerns\WithDocument;
+use Metafori\Etno\Filament\Contracts\HasDocument;
 use Metafori\Etno\Filament\Resources\Items\ItemResource;
 
-class EditItem extends EditRecord
+class EditItem extends EditRecord implements HasDocument
 {
+    use WithDocument;
+
     protected static string $resource = ItemResource::class;
 
     protected function getHeaderActions(): array

--- a/app-modules/etno/src/Filament/Resources/Items/Pages/EditItem.php
+++ b/app-modules/etno/src/Filament/Resources/Items/Pages/EditItem.php
@@ -4,6 +4,7 @@ namespace Metafori\Etno\Filament\Resources\Items\Pages;
 
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
+use Metafori\Etno\Filament\Actions\Items\UploadMediaAction;
 use Metafori\Etno\Filament\Resources\Items\ItemResource;
 
 class EditItem extends EditRecord
@@ -13,11 +14,15 @@ class EditItem extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
-            $this->getSaveFormAction()
-                ->formId('form'),
+            UploadMediaAction::make('upload_media'),
             Actions\DeleteAction::make(),
             Actions\ForceDeleteAction::make(),
             Actions\RestoreAction::make(),
         ];
+    }
+
+    public function hasCombinedRelationManagerTabsWithContent(): bool
+    {
+        return true;
     }
 }

--- a/app-modules/etno/src/Filament/Resources/Items/RelationManagers/MediaRelationManager.php
+++ b/app-modules/etno/src/Filament/Resources/Items/RelationManagers/MediaRelationManager.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Metafori\Etno\Filament\Resources\Items\RelationManagers;
+
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Metafori\Etno\Enums\TranscriptFormat;
+use Metafori\Etno\Filament\Resources\Items\Schemas\MediaForm;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+class MediaRelationManager extends RelationManager
+{
+    protected static string $relationship = 'media';
+
+    public function form(Schema $schema): Schema
+    {
+        return MediaForm::configure($schema);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('mime_type')
+                    ->limit(16)
+                    ->tooltip(fn (Media $record): string => $record->mime_type)
+                    ->label('Type')
+                    ->badge(),
+                TextColumn::make('human_readable_size')
+                    ->label('Size'),
+                TextColumn::make('custom_properties.transcripts')
+                    ->label('Transcripts')
+                    ->getStateUsing(fn (Media $record) => collect(TranscriptFormat::cases())
+                        ->filter(fn (TranscriptFormat $format) => $record->getCustomProperty("transcripts.{$format->value}") !== null)
+                    )
+                    ->placeholder('–')
+                    ->badge(),
+            ])
+            ->actions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->bulkActions([
+                DeleteBulkAction::make(),
+            ])
+            ->reorderable('order_column')
+            ->defaultSort('order_column');
+    }
+}

--- a/app-modules/etno/src/Filament/Resources/Items/Schemas/MediaForm.php
+++ b/app-modules/etno/src/Filament/Resources/Items/Schemas/MediaForm.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Metafori\Etno\Filament\Resources\Items\Schemas;
+
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Schema;
+use Metafori\Etno\Enums\TranscriptFormat;
+use Metafori\Etno\Filament\Forms\Components\Items\TranscriptTextarea;
+
+class MediaForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema->components(self::getComponents())
+            ->columns(2);
+    }
+
+    public static function getComponents(): array
+    {
+        $components = [];
+        $components[] = TextInput::make('name')
+            ->required()
+            ->columnSpanFull();
+
+        foreach (TranscriptFormat::cases() as $format) {
+            $components[] = TranscriptTextarea::make("custom_properties.transcripts.{$format->value}")
+                ->label("Transcript ({$format->getLabel()})")
+                ->placeholder("You can drag & drop a {$format->getLabel()} file here...");
+        }
+
+        return $components;
+    }
+}

--- a/app-modules/etno/src/Filament/Resources/Items/Schemas/MediaForm.php
+++ b/app-modules/etno/src/Filament/Resources/Items/Schemas/MediaForm.php
@@ -15,12 +15,12 @@ class MediaForm
             TextInput::make('name')
                 ->required()
                 ->columnSpanFull(),
-            ...self::transcriptionFields(),
+            ...self::transcriptFields(),
         ])
             ->columns(2);
     }
 
-    public static function transcriptionFields(): iterable
+    public static function transcriptFields(): iterable
     {
         return collect(TranscriptFormat::cases())
             ->map(

--- a/app-modules/etno/src/Filament/Resources/Items/Schemas/MediaForm.php
+++ b/app-modules/etno/src/Filament/Resources/Items/Schemas/MediaForm.php
@@ -11,23 +11,22 @@ class MediaForm
 {
     public static function configure(Schema $schema): Schema
     {
-        return $schema->components(self::getComponents())
+        return $schema->components([
+            TextInput::make('name')
+                ->required()
+                ->columnSpanFull(),
+            ...self::transcriptionFields(),
+        ])
             ->columns(2);
     }
 
-    public static function getComponents(): array
+    public static function transcriptionFields(): iterable
     {
-        $components = [];
-        $components[] = TextInput::make('name')
-            ->required()
-            ->columnSpanFull();
-
-        foreach (TranscriptFormat::cases() as $format) {
-            $components[] = TranscriptTextarea::make("custom_properties.transcripts.{$format->value}")
-                ->label("Transcript ({$format->getLabel()})")
-                ->placeholder("You can drag & drop a {$format->getLabel()} file here...");
-        }
-
-        return $components;
+        return collect(TranscriptFormat::cases())
+            ->map(
+                fn (TranscriptFormat $format) => TranscriptTextarea::make("custom_properties.transcripts.{$format->value}")
+                    ->label("Transcript ({$format->getLabel()})")
+                    ->placeholder("You can drag & drop a {$format->getLabel()} file here...")
+            );
     }
 }

--- a/app-modules/etno/src/Http/Resources/ItemResource.php
+++ b/app-modules/etno/src/Http/Resources/ItemResource.php
@@ -4,9 +4,11 @@ namespace Metafori\Etno\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Gate;
 use Metafori\Core\Http\Resources\KeywordResource;
 use Metafori\Core\Http\Resources\OrganizationResource;
 use Metafori\Core\Http\Resources\PersonResource;
+use Metafori\Etno\Enums\MediaType;
 use Metafori\Etno\Http\Resources\Concerns\InheritsDocument;
 use Metafori\Etno\Http\Resources\Concerns\ResolvesLocality;
 use Metafori\Etno\Models\Item;
@@ -77,6 +79,19 @@ class ItemResource extends JsonResource
             'keywords' => KeywordResource::collection($this->whenLoaded('keywords')),
             'research_collections' => ResearchCollectionResource::collection($this->whenLoaded('researchCollections')),
             'document_id' => $this->document_id,
+            /** @var array{audios?: MediaResource[], documents?: MediaResource[], images?: MediaResource[], videos?: MediaResource[]} */
+            'media' => $this->whenLoaded('media', fn () => $this->when(
+                Gate::allows('viewMedia', $this->resource),
+                fn () => collect([
+                    MediaType::Audio,
+                    MediaType::Document,
+                    MediaType::Image,
+                    MediaType::Video,
+                ])
+                    ->mapWithKeys(fn (MediaType $type) => [$type->value => $this->loadMedia($type->value)])
+                    ->filter(fn ($media) => $media->isNotEmpty())
+                    ->map(MediaResource::collection(...))
+            )),
         ];
     }
 }

--- a/app-modules/etno/src/Http/Resources/MediaResource.php
+++ b/app-modules/etno/src/Http/Resources/MediaResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Metafori\Etno\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\MissingValue;
+use Metafori\Core\Http\Resources\MediaResource as CoreMediaResource;
+use Metafori\Etno\Enums\TranscriptFormat;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+/**
+ * @mixin Media
+ */
+class MediaResource extends CoreMediaResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            ...parent::toArray($request),
+            /** @var string */
+            'transcript' => $this->custom_properties['transcripts'][TranscriptFormat::Txt->value] ?? new MissingValue,
+        ];
+    }
+}

--- a/app-modules/etno/src/Models/Contracts/Inheritable.php
+++ b/app-modules/etno/src/Models/Contracts/Inheritable.php
@@ -13,4 +13,6 @@ interface Inheritable
     public function isInheritableAndInherited(string $attribute): bool;
 
     public function getParent(): ?Model;
+
+    public function resolveInheritableAttribute(string $attribute): mixed;
 }

--- a/app-modules/etno/src/Models/Document.php
+++ b/app-modules/etno/src/Models/Document.php
@@ -68,6 +68,26 @@ class Document extends Model
 
     public function items(): HasMany
     {
-        return $this->hasMany(Item::class);
+        return $this->hasMany(Item::class)
+            ->orderByRaw('LENGTH(suffix)')
+            ->orderBy('suffix');
+    }
+
+    public function generateNextSequenceSuffix(): string
+    {
+        $maxSuffix = $this->items()
+            ->pluck('suffix')
+            ->last();
+
+        if ($maxSuffix === null) {
+            return 'a';
+        }
+
+        return self::incrementSuffix($maxSuffix);
+    }
+
+    public static function incrementSuffix(string $suffix): string
+    {
+        return str_increment($suffix);
     }
 }

--- a/app-modules/etno/src/Models/Item.php
+++ b/app-modules/etno/src/Models/Item.php
@@ -21,11 +21,14 @@ use Metafori\Core\Models\MunicipalityPart;
 use Metafori\Core\Models\Organization;
 use Metafori\Core\Models\Person;
 use Metafori\Core\Models\Region;
+use Metafori\Etno\Enums\MediaType;
 use Metafori\Etno\Models\Concerns\HasDocumentMetadata;
 use Metafori\Etno\Models\Contracts\Inheritable;
 use Metafori\Etno\Models\Pivots\ItemPivot;
+use Spatie\Image\Enums\Fit;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class Item extends Model implements HasMedia, Inheritable
 {
@@ -76,6 +79,43 @@ class Item extends Model implements HasMedia, Inheritable
         'originators',
         'keywords',
         'researchCollections',
+    ];
+
+    protected const array MEDIA_MIME_TYPES_MAP = [
+        // Audio
+        'audio/mpeg' => MediaType::Audio,
+        'audio/wav' => MediaType::Audio,
+        'audio/ogg' => MediaType::Audio,
+        'audio/webm' => MediaType::Audio,
+        'audio/aac' => MediaType::Audio,
+        'audio/mp3' => MediaType::Audio,
+        'audio/flac' => MediaType::Audio,
+        'audio/m4a' => MediaType::Audio,
+        'audio/opus' => MediaType::Audio,
+
+        // Documents
+        'application/pdf' => MediaType::Document,
+
+        // Images
+        'image/jpeg' => MediaType::Image,
+        'image/png' => MediaType::Image,
+        'image/gif' => MediaType::Image,
+        'image/webp' => MediaType::Image,
+        'image/svg+xml' => MediaType::Image,
+        'image/bmp' => MediaType::Image,
+        'image/tiff' => MediaType::Image,
+        'image/avif' => MediaType::Image,
+        'image/heic' => MediaType::Image,
+
+        // Videos
+        'video/mp4' => MediaType::Video,
+        'video/webm' => MediaType::Video,
+        'video/ogg' => MediaType::Video,
+        'video/quicktime' => MediaType::Video,
+        'video/mpeg' => MediaType::Video,
+        'video/avi' => MediaType::Video,
+        'video/mov' => MediaType::Video,
+        'video/wmv' => MediaType::Video,
     ];
 
     protected static function booted(): void
@@ -312,5 +352,64 @@ class Item extends Model implements HasMedia, Inheritable
             'project' => ['id' => $resolveRelationIds('project')],
             ...$resolveLocalityHierarchy(),
         ];
+    }
+
+    public function registerMediaCollections(): void
+    {
+        $this->addMediaCollection(MediaType::Document->value)
+            ->acceptsMimeTypes(self::allowedMimeTypesForCollection(MediaType::Document));
+
+        $this->addMediaCollection(MediaType::Image->value)
+            ->acceptsMimeTypes(self::allowedMimeTypesForCollection(MediaType::Image));
+
+        $this->addMediaCollection(MediaType::Video->value)
+            ->acceptsMimeTypes(self::allowedMimeTypesForCollection(MediaType::Video));
+
+        $this->addMediaCollection(MediaType::Audio->value)
+            ->acceptsMimeTypes(self::allowedMimeTypesForCollection(MediaType::Audio));
+    }
+
+    public function registerMediaConversions(?Media $media = null): void
+    {
+        $this->addMediaConversion('full')
+            ->width(1280)
+            ->height(1280)
+            ->fit(Fit::Contain)
+            ->performOnCollections(MediaType::Image->value);
+
+        $this->addMediaConversion('thumbnail')
+            ->width(300)
+            ->height(300)
+            ->fit(Fit::Crop)
+            ->performOnCollections(MediaType::Image->value);
+    }
+
+    public static function allowedMimeTypesForCollection(MediaType $collection): array
+    {
+        return array_keys(array_filter(self::MEDIA_MIME_TYPES_MAP, fn (MediaType $value) => $value === $collection));
+    }
+
+    public function allowedMediaMimeTypes()
+    {
+        if ($this->media->isEmpty()) {
+            return array_keys(self::MEDIA_MIME_TYPES_MAP);
+        }
+
+        return $this->media
+            ->pluck('collection_name')
+            ->unique()
+            ->map(MediaType::tryFrom(...))
+            ->filter()
+            ->flatMap(self::allowedMimeTypesForCollection(...));
+    }
+
+    public static function getMediaType(string $mimeType): ?MediaType
+    {
+        return self::MEDIA_MIME_TYPES_MAP[$mimeType] ?? null;
+    }
+
+    public static function getMediaCollectionName(string $mimeType): ?string
+    {
+        return self::getMediaType($mimeType)?->value;
     }
 }

--- a/app-modules/etno/src/Models/Item.php
+++ b/app-modules/etno/src/Models/Item.php
@@ -221,6 +221,13 @@ class Item extends Model implements HasMedia, Inheritable
         return $this->document;
     }
 
+    public function resolveInheritableAttribute(string $attribute): mixed
+    {
+        return $this->isInherited($attribute)
+            ? $this->getParent()?->{$attribute}
+            : $this->{$attribute};
+    }
+
     public static function relations(): array
     {
         return self::documentRelations([

--- a/app-modules/etno/src/Models/Item.php
+++ b/app-modules/etno/src/Models/Item.php
@@ -24,10 +24,12 @@ use Metafori\Core\Models\Region;
 use Metafori\Etno\Models\Concerns\HasDocumentMetadata;
 use Metafori\Etno\Models\Contracts\Inheritable;
 use Metafori\Etno\Models\Pivots\ItemPivot;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
 
-class Item extends Model implements Inheritable
+class Item extends Model implements HasMedia, Inheritable
 {
-    use HasDocumentMetadata, HasFactory, Searchable, SoftDeletes;
+    use HasDocumentMetadata, HasFactory, InteractsWithMedia, Searchable, SoftDeletes;
 
     protected $table = 'etno_items';
 

--- a/app-modules/etno/src/Policies/ItemPolicy.php
+++ b/app-modules/etno/src/Policies/ItemPolicy.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Metafori\Etno\Policies;
+
+use Metafori\Core\Models\User;
+use Metafori\Etno\Enums\AccessRights;
+use Metafori\Etno\Models\Item;
+
+class ItemPolicy
+{
+    public function viewMedia(?User $user, Item $item): bool
+    {
+        $accessRights = $item->resolveInheritableAttribute('access_rights');
+
+        return match ($accessRights) {
+            AccessRights::OpenAccess => true,
+            AccessRights::RestrictedAccess => $user !== null,
+            default => false,
+        };
+    }
+}

--- a/app-modules/etno/src/Repositories/ItemRepository.php
+++ b/app-modules/etno/src/Repositories/ItemRepository.php
@@ -20,7 +20,10 @@ class ItemRepository
     public function findOrFail(string $id): Item
     {
         return Item::query()
-            ->with(Item::relations())
+            ->with([
+                'media',
+                ...Item::relations(),
+            ])
             ->where('identifier', $id)
             ->firstOrFail();
     }

--- a/app-modules/etno/tests/Feature/Api/ItemShowTest.php
+++ b/app-modules/etno/tests/Feature/Api/ItemShowTest.php
@@ -1,11 +1,14 @@
 <?php
 
 use Metafori\Core\Models\MunicipalityPart;
+use Metafori\Core\Models\User;
+use Metafori\Etno\Enums\AccessRights;
 use Metafori\Etno\Enums\ProductionMethod;
 use Metafori\Etno\Models\Document;
 use Metafori\Etno\Models\Item;
 use Metafori\Opensearch\Testing\RefreshIndices;
 
+use function Pest\Laravel\actingAs;
 use function Pest\Laravel\getJson;
 
 uses(RefreshIndices::class);
@@ -233,4 +236,54 @@ it('returns 404 for non-existent item', function () {
     $response = getJson(route('api.etno.items.show', 'invalid-id'));
 
     $response->assertStatus(404);
+});
+
+it('shows media when access rights are open access', function () {
+    $item = Item::factory()->withTranscribedMedia()->create();
+    $item->document->update(['access_rights' => AccessRights::OpenAccess]);
+
+    $response = getJson(route('api.etno.items.show', $item->identifier));
+
+    $response->assertStatus(200)
+        ->assertJsonStructure(['data' => ['media' => [
+            'documents' => [['name', 'file_name', 'url', 'transcript']],
+        ]]])
+        ->assertJsonCount(1, 'data.media.documents');
+});
+
+it('does not show media when access rights are restricted and user is not authenticated', function () {
+    $item = Item::factory()->withTranscribedMedia()->create();
+    $item->document->update(['access_rights' => AccessRights::RestrictedAccess]);
+
+    $response = getJson(route('api.etno.items.show', $item->identifier));
+
+    $response->assertStatus(200);
+    expect($response->json('data'))->not->toHaveKey('media');
+});
+
+it('shows media when access rights are restricted and user is authenticated', function () {
+    $item = Item::factory()->withTranscribedMedia()->create();
+    $item->document->update(['access_rights' => AccessRights::RestrictedAccess]);
+
+    $user = User::factory()->create();
+
+    $response = actingAs($user)->getJson(route('api.etno.items.show', $item->identifier));
+
+    $response->assertStatus(200)
+        ->assertJsonStructure(['data' => ['media' => [
+            'documents' => [['name', 'file_name', 'url', 'transcript']],
+        ]]])
+        ->assertJsonCount(1, 'data.media.documents');
+});
+
+it('does not show media when access rights are closed and user is authenticated', function () {
+    $item = Item::factory()->withTranscribedMedia()->create();
+    $item->document->update(['access_rights' => AccessRights::ClosedAccess]);
+
+    $user = User::factory()->create();
+
+    $response = actingAs($user)->getJson(route('api.etno.items.show', $item->identifier));
+
+    $response->assertStatus(200);
+    expect($response->json('data'))->not->toHaveKey('media');
 });

--- a/app-modules/etno/tests/Feature/Filament/Actions/Items/UploadMediaTest.php
+++ b/app-modules/etno/tests/Feature/Filament/Actions/Items/UploadMediaTest.php
@@ -39,7 +39,7 @@ it('uploads media files and assigns custom properties', function () {
             'relation' => 'media',
         ]));
 
-    $media = $item->getMedia()->first();
+    $media = $item->media->first();
     expect($media)->not->toBeNull()
         ->and($media->name)->toBe('test')
         ->and($media->file_name)->toBe('test.jpg')
@@ -63,7 +63,7 @@ it('cannot assign media files of various mime types to one item', function () {
             ],
         ])
         ->assertHasErrors([
-            'mountedActions.0.data.media' => 'The mime type of the file must match the other media files.',
+            'mountedActions.0.data.media' => 'The media type of the file must match the other media files.',
         ])
         ->assertNoRedirect();
 });
@@ -84,7 +84,7 @@ it('cannot assign media files of different mime type than already set', function
             ],
         ])
         ->assertHasErrors([
-            'mountedActions.0.data.media' => 'The mime type of the file must match the other item\'s media files.',
+            'mountedActions.0.data.media' => 'The media type of the file must match the other item\'s media files.',
         ])
         ->assertNoRedirect();
 });
@@ -109,8 +109,8 @@ it('can reorder media files by file name', function () {
         ->callAction(TestAction::make('order_by_name')->schemaComponent('media'))
         ->callMountedAction();
 
-    expect($item->getMedia()->firstWhere('file_name', 'test1.jpg')->order_column)->toBe(1)
-        ->and($item->getMedia()->firstWhere('file_name', 'test2.jpg')->order_column)->toBe(2);
+    expect($item->media->firstWhere('file_name', 'test1.jpg')->order_column)->toBe(1)
+        ->and($item->media->firstWhere('file_name', 'test2.jpg')->order_column)->toBe(2);
 });
 
 it('cannot upload transcripts without media files', function () {

--- a/app-modules/etno/tests/Feature/Filament/Actions/Items/UploadMediaTest.php
+++ b/app-modules/etno/tests/Feature/Filament/Actions/Items/UploadMediaTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Metafori\Etno\Tests\Feature\Filament\Actions\Items;
+
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Http\UploadedFile;
+use Metafori\Core\Models\User;
+use Metafori\Etno\Filament\Resources\Items\ItemResource;
+use Metafori\Etno\Filament\Resources\Items\Pages\EditItem;
+use Metafori\Etno\Models\Item;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    actingAs(User::factory()->admin()->create());
+});
+
+it('uploads media files and assigns custom properties', function () {
+    $item = Item::factory()->create();
+
+    $image = UploadedFile::fake()->create('test.jpg', 100, 'image/jpeg');
+    $transcript = UploadedFile::fake()->createWithContent('test.txt', 'text');
+
+    livewire(EditItem::class, [
+        'parentRecord' => $item->document,
+        'record' => $item->id,
+    ])
+        ->callAction(TestAction::make('upload_media'), [
+            'files' => [
+                $image,
+                $transcript,
+            ],
+        ])
+        ->assertHasNoErrors()
+        ->assertRedirect(ItemResource::getUrl('edit', [
+            'document' => $item->document,
+            'record' => $item,
+            'relation' => 'media',
+        ]));
+
+    $media = $item->getMedia()->first();
+    expect($media)->not->toBeNull()
+        ->and($media->name)->toBe('test')
+        ->and($media->file_name)->toBe('test.jpg')
+        ->and($media->getCustomProperty('transcripts.txt'))->toBe('text');
+});
+
+it('cannot assign media files of various mime types to one item', function () {
+    $item = Item::factory()->create();
+
+    $image = UploadedFile::fake()->create('test.jpg', 100, 'image/jpeg');
+    $video = UploadedFile::fake()->create('test.mp4', 100, 'video/mp4');
+
+    livewire(EditItem::class, [
+        'parentRecord' => $item->document,
+        'record' => $item->id,
+    ])
+        ->callAction(TestAction::make('upload_media'), [
+            'files' => [
+                $image,
+                $video,
+            ],
+        ])
+        ->assertHasErrors([
+            'mountedActions.0.data.media' => 'The mime type of the file must match the other media files.',
+        ])
+        ->assertNoRedirect();
+});
+
+it('cannot assign media files of different mime type than already set', function () {
+    $item = Item::factory()->create();
+    $item->addMedia(UploadedFile::fake()->create('test.jpg', 100, 'image/jpeg'))->toMediaCollection();
+
+    $video = UploadedFile::fake()->create('test.mp4', 100, 'video/mp4');
+
+    livewire(EditItem::class, [
+        'parentRecord' => $item->document,
+        'record' => $item->id,
+    ])
+        ->callAction(TestAction::make('upload_media'), [
+            'files' => [
+                $video,
+            ],
+        ])
+        ->assertHasErrors([
+            'mountedActions.0.data.media' => 'The mime type of the file must match the other item\'s media files.',
+        ])
+        ->assertNoRedirect();
+});
+
+it('can reorder media files by file name', function () {
+    $item = Item::factory()->create();
+
+    $image1 = UploadedFile::fake()->create('test1.jpg', 100, 'image/jpeg');
+    $image2 = UploadedFile::fake()->create('test2.jpg', 100, 'image/jpeg');
+
+    livewire(EditItem::class, [
+        'parentRecord' => $item->document,
+        'record' => $item->id,
+    ])
+        ->mountAction('upload_media')
+        ->fillForm([
+            'files' => [
+                $image2,
+                $image1,
+            ],
+        ])
+        ->callAction(TestAction::make('order_by_name')->schemaComponent('media'))
+        ->callMountedAction();
+
+    expect($item->getMedia()->firstWhere('file_name', 'test1.jpg')->order_column)->toBe(1)
+        ->and($item->getMedia()->firstWhere('file_name', 'test2.jpg')->order_column)->toBe(2);
+});

--- a/app-modules/etno/tests/Feature/Filament/Actions/Items/UploadMediaTest.php
+++ b/app-modules/etno/tests/Feature/Filament/Actions/Items/UploadMediaTest.php
@@ -112,3 +112,21 @@ it('can reorder media files by file name', function () {
     expect($item->getMedia()->firstWhere('file_name', 'test1.jpg')->order_column)->toBe(1)
         ->and($item->getMedia()->firstWhere('file_name', 'test2.jpg')->order_column)->toBe(2);
 });
+
+it('cannot upload transcripts without media files', function () {
+    $item = Item::factory()->create();
+
+    $transcript = UploadedFile::fake()->createWithContent('test.txt', 'text');
+
+    livewire(EditItem::class, [
+        'parentRecord' => $item->document,
+        'record' => $item->id,
+    ])
+        ->callAction(TestAction::make('upload_media'), [
+            'files' => [
+                $transcript,
+            ],
+        ])
+        ->assertHasErrors()
+        ->assertNoRedirect();
+});

--- a/app-modules/etno/tests/Feature/Filament/Actions/Items/UploadMediaTest.php
+++ b/app-modules/etno/tests/Feature/Filament/Actions/Items/UploadMediaTest.php
@@ -127,6 +127,8 @@ it('cannot upload transcripts without media files', function () {
                 $transcript,
             ],
         ])
-        ->assertHasErrors()
+        ->assertHasErrors([
+            'mountedActions.0.data.files' => 'Cannot upload transcripts without corresponding media files.',
+        ])
         ->assertNoRedirect();
 });

--- a/app-modules/etno/tests/Feature/Filament/Items/RelationManagers/MediaRelationManagerTest.php
+++ b/app-modules/etno/tests/Feature/Filament/Items/RelationManagers/MediaRelationManagerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Metafori\Etno\Tests\Feature\Filament\Items\RelationManagers;
+
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Http\UploadedFile;
+use Metafori\Core\Models\User;
+use Metafori\Etno\Filament\Resources\Items\Pages\EditItem;
+use Metafori\Etno\Filament\Resources\Items\RelationManagers\MediaRelationManager;
+use Metafori\Etno\Models\Document;
+use Metafori\Etno\Models\Item;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    $this->user = User::factory()->admin()->create();
+    actingAs($this->user);
+});
+
+it('can edit media', function () {
+    $item = Item::factory()->create();
+    $media = $item->addMedia(UploadedFile::fake()->create('test.jpg'))->toMediaCollection();
+
+    livewire(MediaRelationManager::class, [
+        'ownerRecord' => $item,
+        'pageClass' => EditItem::class,
+    ])
+        ->callAction(TestAction::make('edit')->table($media), [
+            'name' => 'New Name',
+            'custom_properties' => [
+                'transcripts' => [
+                    'xml' => '<?xml version="1.0" encoding="UTF-8"?>',
+                    'txt' => 'text',
+                ],
+            ],
+        ])
+        ->assertHasNoErrors();
+
+    expect($media->refresh()->name)->toBe('New Name')
+        ->and($media->custom_properties['transcripts']['xml'])->toBe('<?xml version="1.0" encoding="UTF-8"?>')
+        ->and($media->custom_properties['transcripts']['txt'])->toBe('text');
+});
+
+it('can delete media', function () {
+    $item = Item::factory()->create();
+
+    $media = $item->addMedia(UploadedFile::fake()->create('test.jpg'))->toMediaCollection();
+
+    livewire(MediaRelationManager::class, [
+        'ownerRecord' => $item,
+        'pageClass' => EditItem::class,
+    ])
+        ->callAction(TestAction::make('delete')->table($media));
+
+    expect(Media::find($media->id))->toBeNull();
+});
+
+it('can bulk delete media', function () {
+    $document = Document::factory()->create();
+    $item = Item::factory()->create(['document_id' => $document->id]);
+
+    $media = [
+        $item->addMedia(UploadedFile::fake()->create('test1.jpg'))->toMediaCollection(),
+        $item->addMedia(UploadedFile::fake()->create('test2.jpg'))->toMediaCollection(),
+    ];
+
+    livewire(MediaRelationManager::class, [
+        'ownerRecord' => $item,
+        'pageClass' => EditItem::class,
+    ])
+        ->selectTableRecords($media)
+        ->callAction(TestAction::make('delete')->table()->bulk());
+
+    expect(Media::find($media[0]->id))->toBeNull()
+        ->and(Media::find($media[1]->id))->toBeNull();
+});

--- a/app-modules/etno/tests/Feature/Filament/Resources/Items/Pages/CreateItemsFromFilesTest.php
+++ b/app-modules/etno/tests/Feature/Filament/Resources/Items/Pages/CreateItemsFromFilesTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Metafori\Etno\Tests\Feature\Filament\Resources\Items\Pages;
+
+use Illuminate\Http\UploadedFile;
+use Metafori\Core\Models\User;
+use Metafori\Etno\Filament\Resources\Items\Pages\CreateItemsFromFiles;
+use Metafori\Etno\Models\Document;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    actingAs(User::factory()->admin()->create());
+});
+
+it('extracts transcripts, syncs items and applies transcripts', function () {
+    $document = Document::factory()->create(['id' => 'AA000001']);
+
+    $image1 = UploadedFile::fake()->create('test1.jpg', 100, 'image/jpeg');
+    $transcript1 = UploadedFile::fake()->create('test1.txt', 'transcript one text', 'text/plain');
+    $image2 = UploadedFile::fake()->create('test2.jpg', 100, 'image/jpeg');
+
+    livewire(CreateItemsFromFiles::class, [
+        'parentRecord' => $document,
+    ])
+        ->fillForm([
+            'files' => [$image1, $transcript1, $image2],
+        ])
+        ->goToNextWizardStep()
+        ->call('createFromFiles')
+        ->assertHasNoFormErrors();
+
+    $items = $document->items()->get();
+    expect($items)->toHaveCount(2);
+
+    $item1 = $items->firstWhere('identifier', 'AA000001:a');
+    $item2 = $items->firstWhere('identifier', 'AA000001:b');
+
+    expect($item1->media)->toHaveCount(1);
+    expect($item1->media->first()->custom_properties['transcripts']['txt'])->toBe('transcript one text');
+    expect($item2->media)->toHaveCount(1);
+    expect($item2->media->first()->custom_properties['transcripts']['txt'])->toBeNull();
+});

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -32,7 +32,7 @@ return [
      * The disk on which to store added files and derived images by default. Choose
      * one or more of the disks you've configured in config/filesystems.php.
      */
-    'disk_name' => env('MEDIA_DISK', 'public'),
+    'disk_name' => env('MEDIA_DISK', 'local'),
 
     /*
      * The maximum file size of an item in bytes.

--- a/storage/media-library/.gitignore
+++ b/storage/media-library/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-file media upload UI with transcript extraction, assignment, validation, and redirect to media editor
  * Media relation panel: list, reorder, edit, delete, and transcript badges
  * Support for TXT and XML transcript formats with per-format transcript fields and drag-and-drop transcript textarea
  * Item model: media library integration with MIME-type-based collections and validation; media form/repeater with "Order by Name"

* **Tests**
  * End-to-end tests for uploads, transcript handling, MIME validation, reordering, and relation manager actions

* **Chores**
  * Media storage directory ignored from version control
<!-- end of auto-generated comment: release notes by coderabbit.ai -->