### PR TITLE
feat(etno): order item filenames action

### DIFF
--- a/app-modules/etno/src/Filament/Actions/Items/OrderFilesByNameAction.php
+++ b/app-modules/etno/src/Filament/Actions/Items/OrderFilesByNameAction.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Metafori\Etno\Filament\Actions\Items;
+
+use Filament\Actions\Action;
+use Filament\Forms\Components\Repeater;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Support\Arr;
+
+class OrderFilesByNameAction extends Action
+{
+    protected ?string $fileStatePath = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->label('Order by Name')
+            ->icon(Heroicon::BarsArrowDown)
+            ->hidden(fn (?array $state): bool => \count($state ?? []) < 2)
+            ->action(function (Repeater $component) {
+                $state = $component->getState();
+                uasort($state, function ($a, $b) {
+                    $path = $this->fileStatePath;
+
+                    $fileA = $path ? Arr::get($a, $path) : $a;
+                    $fileB = $path ? Arr::get($b, $path) : $b;
+
+                    if ($fileA === null || $fileB === null) {
+                        return 0;
+                    }
+
+                    return strnatcasecmp(
+                        $fileA->getClientOriginalName(),
+                        $fileB->getClientOriginalName()
+                    );
+                });
+
+                $component->state($state);
+            });
+    }
+
+    public function fileStatePath(?string $path): static
+    {
+        $this->fileStatePath = $path;
+
+        return $this;
+    }
+}

--- a/app-modules/etno/src/Filament/Actions/Items/OrderFilesByNameAction.php
+++ b/app-modules/etno/src/Filament/Actions/Items/OrderFilesByNameAction.php
@@ -46,4 +46,9 @@ class OrderFilesByNameAction extends Action
 
         return $this;
     }
+
+    public function getFileStatePath(): ?string
+    {
+        return $this->fileStatePath;
+    }
 }

--- a/app-modules/etno/src/Filament/Forms/Components/Items/ItemsFromFilesRepeater.php
+++ b/app-modules/etno/src/Filament/Forms/Components/Items/ItemsFromFilesRepeater.php
@@ -9,6 +9,7 @@ use Filament\Forms\Components\Repeater\TableColumn;
 use Filament\Schemas\Components\Section;
 use Filament\Support\Icons\Heroicon;
 use Metafori\Etno\Enums\TranscriptFormat;
+use Metafori\Etno\Filament\Actions\Items\OrderFilesByNameAction;
 use Metafori\Etno\Filament\Forms\Components\SuffixInput;
 use Metafori\Etno\Filament\Resources\Items\Schemas\MediaForm;
 
@@ -55,7 +56,11 @@ class ItemsFromFilesRepeater extends Repeater
             ->collapsible()
             ->collapsed()
             ->addable(false)
-            ->reorderableWithDragAndDrop();
+            ->reorderableWithDragAndDrop()
+            ->hintAction(
+                OrderFilesByNameAction::make('order_by_name')
+                    ->fileStatePath('media.file')
+            );
     }
 
     public function hasTranscript(TranscriptFormat $format, string $item, self $component): bool

--- a/app-modules/etno/src/Filament/Forms/Components/Items/MediaRepeater.php
+++ b/app-modules/etno/src/Filament/Forms/Components/Items/MediaRepeater.php
@@ -7,6 +7,7 @@ use Filament\Actions\Action;
 use Filament\Forms\Components\Repeater;
 use Filament\Support\Icons\Heroicon;
 use Metafori\Etno\Enums\TranscriptFormat;
+use Metafori\Etno\Filament\Actions\Items\OrderFilesByNameAction;
 use Metafori\Etno\Filament\Resources\Items\Schemas\MediaForm;
 use Metafori\Etno\Models\Item;
 
@@ -59,18 +60,8 @@ class MediaRepeater extends Repeater
             ->addable(false)
             ->reorderableWithDragAndDrop()
             ->hintAction(
-                Action::make('order_by_name')
-                    ->hidden(fn (array $state) => \count($state ?? []) < 2)
-                    ->label('Order by Name')
-                    ->icon(Heroicon::BarsArrowDown)
-                    ->action(function (self $component) {
-                        $state = $component->getState();
-                        uasort($state, fn ($a, $b) => strnatcasecmp(
-                            $a['file']->getClientOriginalName(),
-                            $b['file']->getClientOriginalName()
-                        ));
-                        $component->state($state);
-                    })
+                OrderFilesByNameAction::make('order_by_name')
+                    ->fileStatePath('file')
             );
     }
 

--- a/app-modules/etno/tests/Feature/Filament/Resources/Items/Pages/CreateItemsFromFilesTest.php
+++ b/app-modules/etno/tests/Feature/Filament/Resources/Items/Pages/CreateItemsFromFilesTest.php
@@ -42,3 +42,32 @@ it('extracts transcripts, syncs items and applies transcripts', function () {
     expect($item2->media)->toHaveCount(1);
     expect($item2->media->first()->custom_properties['transcripts']['txt'])->toBeNull();
 });
+
+it('can reorder items by file name', function () {
+    $document = Document::factory()->create(['id' => 'AA000001']);
+
+    $image1 = UploadedFile::fake()->create('z_test.jpg', 100, 'image/jpeg');
+    $image2 = UploadedFile::fake()->create('a_test.jpg', 100, 'image/jpeg');
+
+    $livewire = livewire(CreateItemsFromFiles::class, [
+        'parentRecord' => $document,
+    ])
+        ->fillForm([
+            'files' => [$image1, $image2],
+        ])
+        ->goToNextWizardStep();
+
+    $itemsState = $livewire->instance()->form->getState()['items'];
+    $keys = array_keys($itemsState);
+
+    expect($itemsState[$keys[0]]['media']['file']->getClientOriginalName())->toBe('z_test.jpg')
+        ->and($itemsState[$keys[1]]['media']['file']->getClientOriginalName())->toBe('a_test.jpg');
+
+    $livewire->callFormComponentAction('items', 'order_by_name');
+
+    $itemsState = $livewire->instance()->form->getState()['items'];
+    $keys = array_keys($itemsState);
+
+    expect($itemsState[$keys[0]]['media']['file']->getClientOriginalName())->toBe('a_test.jpg')
+        ->and($itemsState[$keys[1]]['media']['file']->getClientOriginalName())->toBe('z_test.jpg');
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Order by Name" action to repeater file lists to alphabetically sort items by filename; action auto-hides when fewer than two items and supports configurable file location within each item.
* **Tests**
  * Added an automated test verifying files are reordered alphabetically when the action is invoked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->