### PR TITLE
feat(etno): add first media to items index

### DIFF
--- a/app-modules/etno/src/Http/Resources/ItemResource.php
+++ b/app-modules/etno/src/Http/Resources/ItemResource.php
@@ -79,6 +79,10 @@ class ItemResource extends JsonResource
             'keywords' => KeywordResource::collection($this->whenLoaded('keywords')),
             'research_collections' => ResearchCollectionResource::collection($this->whenLoaded('researchCollections')),
             'document_id' => $this->document_id,
+            'first_media' => $this->whenLoaded('firstMedia', fn () => $this->when(
+                Gate::allows('viewMedia', $this->resource),
+                fn () => new MediaResource($this->firstMedia)
+            )),
             /** @var array{audios?: MediaResource[], documents?: MediaResource[], images?: MediaResource[], videos?: MediaResource[]} */
             'media' => $this->whenLoaded('media', fn () => $this->when(
                 Gate::allows('viewMedia', $this->resource),

--- a/app-modules/etno/src/Models/Item.php
+++ b/app-modules/etno/src/Models/Item.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
@@ -195,6 +196,13 @@ class Item extends Model implements HasMedia, Inheritable
     public function document(): BelongsTo
     {
         return $this->belongsTo(Document::class);
+    }
+
+    public function firstMedia(): MorphOne
+    {
+        return $this->media()
+            ->one()
+            ->ofMany('order_column', 'min');
     }
 
     public function isInheritable(string $attribute): bool

--- a/app-modules/etno/src/Repositories/ItemRepository.php
+++ b/app-modules/etno/src/Repositories/ItemRepository.php
@@ -53,12 +53,15 @@ class ItemRepository
         }
 
         $query->query(function ($eloquentQuery) {
-            $eloquentQuery->with(Item::documentRelations([
-                'authors',
-                'researchers',
-                'originators.person',
-                ...Item::localityRelations(),
-            ]));
+            $eloquentQuery->with([
+                'firstMedia',
+                ...Item::documentRelations([
+                    'authors',
+                    'researchers',
+                    'originators.person',
+                    ...Item::localityRelations(),
+                ]),
+            ]);
         });
 
         $perPage = request()->query('per_page', 15);

--- a/app-modules/etno/tests/Feature/Api/ItemIndexTest.php
+++ b/app-modules/etno/tests/Feature/Api/ItemIndexTest.php
@@ -507,3 +507,30 @@ it('can filter items by all filterables at once', function () {
         ->assertJsonCount(1, 'data')
         ->assertJsonPath('data.0.id', $matching->identifier);
 });
+
+it('shows first media in index when access rights are open access', function () {
+    $item = Item::factory()->withTranscribedMedia()->create();
+    $item->document->update(['access_rights' => AccessRights::OpenAccess]);
+
+    app(ItemRepository::class)->refreshIndex();
+
+    $response = getJson(route('api.etno.items.index'));
+
+    $response->assertStatus(200)
+        ->assertJsonStructure(['data' => [['first_media' => [
+            'name', 'file_name', 'url', 'transcript',
+        ]]]]);
+    expect($response->json('data.0.first_media'))->not->toBeNull();
+});
+
+it('does not show first media in index when access rights are restricted and user is unauthenticated', function () {
+    $item = Item::factory()->withTranscribedMedia()->create();
+    $item->document->update(['access_rights' => AccessRights::RestrictedAccess]);
+
+    app(ItemRepository::class)->refreshIndex();
+
+    $response = getJson(route('api.etno.items.index'));
+
+    $response->assertStatus(200);
+    expect($response->json('data.0'))->not->toHaveKey('first_media');
+});

--- a/app-modules/etno/tests/Feature/Api/ItemShowTest.php
+++ b/app-modules/etno/tests/Feature/Api/ItemShowTest.php
@@ -15,6 +15,7 @@ uses(RefreshIndices::class);
 
 it('can show a complete item with all relations', function () {
     $document = Document::factory()
+        ->state(['access_rights' => AccessRights::OpenAccess])
         ->hasAuthors(2)
         ->hasResearchers(2)
         ->hasKeywords(2)
@@ -22,6 +23,7 @@ it('can show a complete item with all relations', function () {
         ->hasOriginators(2)
         ->for(MunicipalityPart::factory(), 'locality');
     $item = Item::factory()
+        ->withTranscribedMedia()
         ->for($document, 'document')
         ->create();
 
@@ -49,6 +51,20 @@ it('can show a complete item with all relations', function () {
                 'content_note',
                 'technical_note',
                 'type',
+                'media' => [
+                    'documents' => [
+                        '*' => [
+                            'conversions',
+                            'file_name',
+                            'human_readable_size',
+                            'id',
+                            'mime_type',
+                            'name',
+                            'transcript',
+                            'url',
+                        ],
+                    ],
+                ],
                 'language',
                 'accrual_method',
                 'collection_method',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Item API responses now include a conditional first_media object (name, file_name, url, transcript and related media fields) showing the primary media asset when allowed by access permissions.

* **Tests**
  * Added/updated API tests to assert the conditional presence or absence of first_media and the extended media fields based on document access rights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->