### PR TITLE
feat(etno): publish documents/items based on access rights

### DIFF
--- a/app-modules/etno/database/factories/DocumentFactory.php
+++ b/app-modules/etno/database/factories/DocumentFactory.php
@@ -3,6 +3,7 @@
 namespace Metafori\Etno\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Metafori\Etno\Enums\AccessRights;
 use Metafori\Etno\Models\Document;
 
 /**
@@ -26,5 +27,18 @@ class DocumentFactory extends Factory
             'id' => fake()->unique()->regexify('[A-Z]{2}[0-9]{5,6}'),
             ...$this->documentAttributes(),
         ];
+    }
+
+    public function published(bool $published = true): self
+    {
+        $accessRights = fake()->randomElement(
+            $published
+            ? AccessRights::published()
+            : [AccessRights::ClosedAccess, null]
+        );
+
+        return $this->state([
+            'access_rights' => $accessRights,
+        ]);
     }
 }

--- a/app-modules/etno/database/factories/ItemFactory.php
+++ b/app-modules/etno/database/factories/ItemFactory.php
@@ -4,6 +4,7 @@ namespace Metafori\Etno\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Http\UploadedFile;
+use Metafori\Etno\Enums\AccessRights;
 use Metafori\Etno\Models\Document;
 use Metafori\Etno\Models\Item;
 
@@ -36,6 +37,25 @@ class ItemFactory extends Factory
         return $this->state([
             'document_overrides' => Item::INHERITABLES,
         ]);
+    }
+
+    public function published(bool $published = true): self
+    {
+        return $this->state(function (array $attributes) use ($published) {
+            $attributes['document_overrides'][] = 'access_rights';
+            $attributes['document_overrides'] = array_unique($attributes['document_overrides']);
+
+            $accessRights = fake()->randomElement(
+                $published
+                ? AccessRights::published()
+                : [AccessRights::ClosedAccess, null]
+            );
+
+            return [
+                'access_rights' => $accessRights,
+                'document_overrides' => $attributes['document_overrides'],
+            ];
+        });
     }
 
     public function withMedia(string $filename = 'document.pdf', array $customProperties = [], string $collection = 'documents', string $content = '%PDF-1.4'): static

--- a/app-modules/etno/src/Enums/AccessRights.php
+++ b/app-modules/etno/src/Enums/AccessRights.php
@@ -15,4 +15,15 @@ enum AccessRights: string implements HasLabel
     case MetadataOnlyAccess = 'metadata-only-access';
     case PaidAccess = 'paid-access';
     case ClosedAccess = 'closed-access';
+
+    public static function published(): array
+    {
+        return [
+            self::OpenAccess,
+            self::RestrictedAccess,
+            self::EmbargoedAccess,
+            self::MetadataOnlyAccess,
+            self::PaidAccess,
+        ];
+    }
 }

--- a/app-modules/etno/src/Models/DocumentOriginator.php
+++ b/app-modules/etno/src/Models/DocumentOriginator.php
@@ -12,6 +12,8 @@ class DocumentOriginator extends Model
 
     protected $table = 'etno_document_originators';
 
+    protected $touches = ['document'];
+
     protected $guarded = [];
 
     public function document(): BelongsTo

--- a/app-modules/etno/src/Models/Item.php
+++ b/app-modules/etno/src/Models/Item.php
@@ -12,7 +12,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Support\Collection;
 use Laravel\Scout\Searchable;
 use Metafori\Core\Models\District;
 use Metafori\Core\Models\Keyword;
@@ -22,6 +21,7 @@ use Metafori\Core\Models\MunicipalityPart;
 use Metafori\Core\Models\Organization;
 use Metafori\Core\Models\Person;
 use Metafori\Core\Models\Region;
+use Metafori\Etno\Enums\AccessRights;
 use Metafori\Etno\Enums\MediaType;
 use Metafori\Etno\Models\Concerns\HasDocumentMetadata;
 use Metafori\Etno\Models\Contracts\Inheritable;
@@ -277,34 +277,40 @@ class Item extends Model implements HasMedia, Inheritable
         ];
     }
 
+    public function shouldBeSearchable(): bool
+    {
+        return $this->isPublished();
+    }
+
+    public function isPublished(): bool
+    {
+        return \in_array(
+            $this->resolveInheritableAttribute('access_rights'),
+            AccessRights::published(),
+        );
+    }
+
+    public function scopePublished(Builder $query): void
+    {
+        $query->where(function (Builder $query) {
+            $query->where(function (Builder $q) {
+                $q->whereJsonContains('etno_items.document_overrides', 'access_rights')
+                    ->whereIn('etno_items.access_rights', AccessRights::published());
+            })->orWhere(function (Builder $q) {
+                $q->whereJsonDoesntContain('etno_items.document_overrides', 'access_rights')
+                    ->whereHas('document', function (Builder $dq) {
+                        $dq->whereIn('etno_documents.access_rights', AccessRights::published());
+                    });
+            });
+        });
+    }
+
     public function toSearchableArray(): array
     {
         $this->loadMissing(self::relations());
 
-        $resolveRelationIds = function (string $relation, string $key = 'id') {
-            $value = $this->isInheritableAndInherited($relation)
-                ? $this->getParent()?->{$relation}
-                : $this->{$relation};
-
-            if ($value === null) {
-                return [];
-            }
-
-            if ($value instanceof Collection) {
-                return $value->pluck($key)->toArray();
-            }
-
-            return [$value->{$key}];
-        };
-
-        $resolveValue = function (string $attribute) {
-            return $this->isInheritableAndInherited($attribute)
-                ? $this->document?->{$attribute}
-                : $this->{$attribute};
-        };
-
         $resolveTranslations = function (string $attribute) {
-            if ($this->isInheritableAndInherited($attribute)) {
+            if ($this->isInherited($attribute)) {
                 return $this->document?->getTranslations($attribute) ?? [];
             }
 
@@ -312,9 +318,7 @@ class Item extends Model implements HasMedia, Inheritable
         };
 
         $resolveLocalityHierarchy = function () {
-            $locality = $this->isInheritableAndInherited('locality')
-                ? $this->getParent()?->locality
-                : $this->locality;
+            $locality = $this->resolveInheritableAttribute('locality');
 
             if (! $locality) {
                 return [];
@@ -351,24 +355,24 @@ class Item extends Model implements HasMedia, Inheritable
             'location_note' => $resolveTranslations('location_note'),
             'content_note' => $resolveTranslations('content_note'),
             'technical_note' => $resolveTranslations('technical_note'),
-            'type' => $resolveValue('type')?->value,
-            'language' => $resolveValue('language')?->value,
-            'accrual_method' => $resolveValue('accrual_method')?->value,
-            'collection_method' => $resolveValue('collection_method')?->value,
-            'access_rights' => $resolveValue('access_rights')?->value,
-            'license' => $resolveValue('license')?->value,
-            'production_methods' => collect($resolveValue('production_methods'))->map->value->toArray(),
+            'type' => $this->resolveInheritableAttribute('type')?->value,
+            'language' => $this->resolveInheritableAttribute('language')?->value,
+            'accrual_method' => $this->resolveInheritableAttribute('accrual_method')?->value,
+            'collection_method' => $this->resolveInheritableAttribute('collection_method')?->value,
+            'access_rights' => $this->resolveInheritableAttribute('access_rights')?->value,
+            'license' => $this->resolveInheritableAttribute('license')?->value,
+            'production_methods' => collect($this->resolveInheritableAttribute('production_methods'))->map->value->toArray(),
             'time_period' => \array_filter([
-                'gte' => $resolveValue('time_period_start'),
-                'lte' => $resolveValue('time_period_end'),
+                'gte' => $this->resolveInheritableAttribute('time_period_start'),
+                'lte' => $this->resolveInheritableAttribute('time_period_end'),
             ]),
-            'author' => ['person_id' => $resolveRelationIds('authors')],
-            'researcher' => ['person_id' => $resolveRelationIds('researchers')],
-            'originator' => ['person_id' => $resolveRelationIds('originators', 'person_id')],
-            'keyword' => ['id' => $resolveRelationIds('keywords')],
-            'research_collection' => ['id' => $resolveRelationIds('researchCollections')],
-            'institution' => ['id' => $resolveRelationIds('institution')],
-            'project' => ['id' => $resolveRelationIds('project')],
+            'author' => ['person_id' => $this->resolveInheritableAttribute('authors')->pluck('id')],
+            'researcher' => ['person_id' => $this->resolveInheritableAttribute('researchers')->pluck('id')],
+            'originator' => ['person_id' => $this->resolveInheritableAttribute('originators')->pluck('person_id')],
+            'keyword' => ['id' => $this->resolveInheritableAttribute('keywords')->pluck('id')],
+            'research_collection' => ['id' => $this->resolveInheritableAttribute('researchCollections')->pluck('id')],
+            'institution' => ['id' => $this->resolveInheritableAttribute('institution_id')],
+            'project' => ['id' => $this->resolveInheritableAttribute('project_id')],
             ...$resolveLocalityHierarchy(),
         ];
     }

--- a/app-modules/etno/src/Observers/DocumentObserver.php
+++ b/app-modules/etno/src/Observers/DocumentObserver.php
@@ -11,11 +11,11 @@ class DocumentObserver
 
     public function updated(Document $document): void
     {
-        if ($document->wasChanged('locality_id') || $document->wasChanged('locality_type')) {
+        if ($document->wasChanged(['locality_id', 'locality_type', 'access_rights'])) {
             $this->repository->invalidateMapPointsCache();
         }
 
-        $document->items()->searchable();
+        $this->syncSearchableItems($document);
     }
 
     public function deleted(Document $document): void
@@ -41,6 +41,15 @@ class DocumentObserver
             $this->repository->invalidateMapPointsCache();
         }
 
-        $document->items()->searchable();
+        $this->syncSearchableItems($document);
+    }
+
+    protected function syncSearchableItems(Document $document): void
+    {
+        $items = $document->items()->get();
+        [$searchable, $unsearchable] = $items->partition->shouldBeSearchable();
+
+        $searchable->searchable();
+        $unsearchable->unsearchable();
     }
 }

--- a/app-modules/etno/src/Observers/ItemObserver.php
+++ b/app-modules/etno/src/Observers/ItemObserver.php
@@ -18,7 +18,7 @@ class ItemObserver
 
     public function updated(Item $item): void
     {
-        if ($item->wasChanged('locality_id') || $item->wasChanged('locality_type')) {
+        if ($item->wasChanged(['locality_id', 'locality_type', 'access_rights', 'document_overrides'])) {
             $this->repository->invalidateMapPointsCache();
         }
     }

--- a/app-modules/etno/src/Repositories/ItemRepository.php
+++ b/app-modules/etno/src/Repositories/ItemRepository.php
@@ -21,6 +21,7 @@ class ItemRepository
     public function findOrFail(string $id): Item
     {
         return Item::query()
+            ->published()
             ->with([
                 'media',
                 ...Item::relations(),
@@ -167,6 +168,7 @@ class ItemRepository
         return Cache::rememberForever(
             self::MAP_POINTS_CACHE_KEY,
             Item::query()
+                ->published()
                 ->select([
                     'document_id',
                     'suffix',

--- a/app-modules/etno/tests/Feature/Api/ItemAggregationsTest.php
+++ b/app-modules/etno/tests/Feature/Api/ItemAggregationsTest.php
@@ -12,8 +12,8 @@ use Metafori\Etno\Enums\AccrualMethod;
 use Metafori\Etno\Enums\CollectionMethod;
 use Metafori\Etno\Enums\ItemType;
 use Metafori\Etno\Enums\ProductionMethod;
-use Metafori\Etno\Models\Item;
-use Metafori\Etno\Models\ItemOriginator;
+use Metafori\Etno\Models\Document;
+use Metafori\Etno\Models\DocumentOriginator;
 use Metafori\Etno\Models\Project;
 use Metafori\Etno\Models\ResearchCollection;
 use Metafori\Etno\Repositories\ItemRepository;
@@ -24,15 +24,15 @@ use function Pest\Laravel\getJson;
 uses(RefreshIndices::class);
 
 it('can get aggregations for items', function () {
-    Item::factory()->create([
-        'type' => ItemType::AudioRecording,
-        'document_overrides' => ['type'],
-    ]);
+    Document::factory()
+        ->hasItems(1)
+        ->published()
+        ->create(['type' => ItemType::AudioRecording]);
 
-    Item::factory()->count(2)->create([
-        'type' => ItemType::Map,
-        'document_overrides' => ['type'],
-    ]);
+    Document::factory()
+        ->hasItems(2)
+        ->published()
+        ->create(['type' => ItemType::Map]);
 
     app(ItemRepository::class)->refreshIndex();
 
@@ -60,17 +60,21 @@ it('can filter aggregations by another property', function () {
     $org1 = Organization::factory()->create();
     $org2 = Organization::factory()->create();
 
-    Item::factory()->create([
-        'type' => ItemType::AudioRecording,
-        'institution_id' => $org1->id,
-        'document_overrides' => ['type', 'institution'],
-    ]);
+    Document::factory()
+        ->hasItems(1)
+        ->published()
+        ->create([
+            'type' => ItemType::AudioRecording,
+            'institution_id' => $org1->id,
+        ]);
 
-    Item::factory()->create([
-        'type' => ItemType::Map,
-        'institution_id' => $org2->id,
-        'document_overrides' => ['type', 'institution'],
-    ]);
+    Document::factory()
+        ->hasItems(2)
+        ->published()
+        ->create([
+            'type' => ItemType::Map,
+            'institution_id' => $org2->id,
+        ]);
 
     app(ItemRepository::class)->refreshIndex();
 
@@ -90,17 +94,21 @@ it('ignores filters for the same field when aggregating', function () {
     $org1 = Organization::factory()->create();
     $org2 = Organization::factory()->create();
 
-    Item::factory()->create([
-        'type' => ItemType::AudioRecording,
-        'institution_id' => $org1->id,
-        'document_overrides' => ['type', 'institution'],
-    ]);
+    Document::factory()
+        ->hasItems(1)
+        ->published()
+        ->create([
+            'type' => ItemType::AudioRecording,
+            'institution_id' => $org1->id,
+        ]);
 
-    Item::factory()->create([
-        'type' => ItemType::Map,
-        'institution_id' => $org2->id,
-        'document_overrides' => ['type', 'institution'],
-    ]);
+    Document::factory()
+        ->hasItems(1)
+        ->published()
+        ->create([
+            'type' => ItemType::Map,
+            'institution_id' => $org2->id,
+        ]);
 
     app(ItemRepository::class)->refreshIndex();
 
@@ -125,10 +133,10 @@ it('ignores filters for the same field when aggregating', function () {
 it('resolves model labels for aggregations', function () {
     $org = Organization::factory()->create(['name' => 'Test Organization']);
 
-    Item::factory()->create([
-        'institution_id' => $org->id,
-        'document_overrides' => ['institution'],
-    ]);
+    Document::factory()
+        ->hasItems(1)
+        ->published()
+        ->create(['institution_id' => $org->id]);
 
     app(ItemRepository::class)->refreshIndex();
 
@@ -149,19 +157,23 @@ it('can filter aggregations by time period', function () {
     $matchingOrg = Organization::factory()->create();
     $otherOrg = Organization::factory()->create();
 
-    Item::factory()->create([
-        'institution_id' => $matchingOrg->id,
-        'time_period_start' => '1950-12-31',
-        'time_period_end' => '1950-12-31',
-        'document_overrides' => ['institution', 'time_period_start', 'time_period_end'],
-    ]);
+    Document::factory()
+        ->hasItems(1)
+        ->published()
+        ->create([
+            'institution_id' => $matchingOrg->id,
+            'time_period_start' => '1950-12-31',
+            'time_period_end' => '1950-12-31',
+        ]);
 
-    Item::factory()->create([
-        'institution_id' => $otherOrg->id,
-        'time_period_start' => '1800-01-01',
-        'time_period_end' => '1840-01-01',
-        'document_overrides' => ['institution', 'time_period_start', 'time_period_end'],
-    ]);
+    Document::factory()
+        ->hasItems(1)
+        ->published()
+        ->create([
+            'institution_id' => $otherOrg->id,
+            'time_period_start' => '1800-01-01',
+            'time_period_end' => '1840-01-01',
+        ]);
 
     app(ItemRepository::class)->refreshIndex();
 
@@ -197,12 +209,15 @@ it('can filter aggregations by all filterables at once', function () {
     $researchCollection = ResearchCollection::factory()->create();
     $originatorPerson = Person::factory()->create();
 
-    $matching = Item::factory()
+    Document::factory()
+        ->published()
         ->for($location, 'locality')
         ->hasAttached($author, [], 'authors')
         ->hasAttached($researcher, [], 'researchers')
         ->hasAttached($keyword, [], 'keywords')
         ->hasAttached($researchCollection, [], 'researchCollections')
+        ->has(DocumentOriginator::factory()->for($originatorPerson), 'originators')
+        ->hasItems(1)
         ->create([
             'type' => ItemType::AudioRecording,
             'language' => Language::Slovak,
@@ -215,13 +230,7 @@ it('can filter aggregations by all filterables at once', function () {
             'project_id' => $project->id,
             'time_period_start' => '1900-01-01',
             'time_period_end' => '1950-01-01',
-            'document_overrides' => Item::INHERITABLES,
         ]);
-
-    ItemOriginator::factory()
-        ->for($matching)
-        ->for($originatorPerson)
-        ->create();
 
     app(ItemRepository::class)->refreshIndex();
 
@@ -256,4 +265,20 @@ it('can filter aggregations by all filterables at once', function () {
 
     expect(collect($data['type'])->firstWhere('value', ItemType::AudioRecording->value)['count'])->toBe(1)
         ->and(collect($data['type'])->firstWhere('value', ItemType::Map->value))->toBeNull();
+});
+
+it('does not include unpublished items in aggregations', function () {
+    Document::factory()
+        ->hasItems(1)
+        ->published(false)
+        ->create(['type' => ItemType::Map]);
+
+    app(ItemRepository::class)->refreshIndex();
+
+    $response = getJson(route('api.etno.items.aggregations'));
+    $response->assertStatus(200);
+
+    $typeData = $response->json('data.type');
+
+    expect(collect($typeData)->firstWhere('value', ItemType::Map->value))->toBeNull();
 });

--- a/app-modules/etno/tests/Feature/Api/ItemIndexTest.php
+++ b/app-modules/etno/tests/Feature/Api/ItemIndexTest.php
@@ -17,6 +17,7 @@ use Metafori\Etno\Enums\CollectionMethod;
 use Metafori\Etno\Enums\ItemType;
 use Metafori\Etno\Enums\ProductionMethod;
 use Metafori\Etno\Models\Document;
+use Metafori\Etno\Models\DocumentOriginator;
 use Metafori\Etno\Models\Item;
 use Metafori\Etno\Models\ItemOriginator;
 use Metafori\Etno\Models\Project;
@@ -29,13 +30,12 @@ use function Pest\Laravel\getJson;
 uses(RefreshIndices::class);
 
 it('can list items', function () {
-    $document = Document::factory()
+    Document::factory()
+        ->published()
+        ->hasItems(2)
         ->hasAuthors(2)
         ->hasResearchers(2)
-        ->hasOriginators(2);
-    Item::factory()
-        ->count(2)
-        ->for($document, 'document')
+        ->hasOriginators(2)
         ->create();
 
     app(ItemRepository::class)->refreshIndex();
@@ -94,15 +94,14 @@ it('can filter items by simple property', function (string $property, string $en
     $matchingValue = $cases->first();
     $otherValue = $cases->last();
 
-    $matchingItem = Item::factory()->create([
-        $property => $matchingValue,
-        'document_overrides' => [$property],
-    ]);
+    $matchingItem = Item::factory()
+        ->for(Document::factory()->published()->create([$property => $matchingValue]))
+        ->create();
 
-    Item::factory()->count(2)->create([
-        $property => $otherValue,
-        'document_overrides' => [$property],
-    ]);
+    Item::factory()
+        ->for(Document::factory()->published()->create([$property => $otherValue]))
+        ->count(2)
+        ->create();
 
     app(ItemRepository::class)->refreshIndex();
 
@@ -118,7 +117,6 @@ it('can filter items by simple property', function (string $property, string $en
     'language' => ['language', Language::class],
     'accrual_method' => ['accrual_method', AccrualMethod::class],
     'collection_method' => ['collection_method', CollectionMethod::class],
-    'access_rights' => ['access_rights', AccessRights::class],
     'license' => ['license', License::class],
 ]);
 
@@ -127,13 +125,19 @@ it('can filter items by simple property inherited', function (string $property, 
     $matchingValue = $cases->first();
     $otherValue = $cases->last();
 
-    Item::factory()
+    $otherDocument = Document::factory()
+        ->published()
+        ->create([$property => $otherValue]);
+    $otherItem = Item::factory()
         ->count(2)
-        ->for(Document::factory()->create([$property => $otherValue]), 'document')
+        ->for($otherDocument)
         ->create();
 
+    $matchingDocument = Document::factory()
+        ->published()
+        ->create([$property => $matchingValue]);
     $matchingItem = Item::factory()
-        ->for(Document::factory()->create([$property => $matchingValue]), 'document')
+        ->for($matchingDocument)
         ->create();
 
     app(ItemRepository::class)->refreshIndex();
@@ -150,20 +154,21 @@ it('can filter items by simple property inherited', function (string $property, 
     'language' => ['language', Language::class],
     'accrual_method' => ['accrual_method', AccrualMethod::class],
     'collection_method' => ['collection_method', CollectionMethod::class],
-    'access_rights' => ['access_rights', AccessRights::class],
     'license' => ['license', License::class],
 ]);
 
 it('can filter items by array property', function () {
-    $matchingItem = Item::factory()->create([
-        'production_methods' => [ProductionMethod::Drawing],
-        'document_overrides' => ['production_methods'],
-    ]);
+    $matchingItem = Item::factory()
+        ->for(Document::factory()->published()->create([
+            'production_methods' => [ProductionMethod::Drawing],
+        ]))
+        ->create();
 
-    Item::factory()->create([
-        'production_methods' => [ProductionMethod::Painting],
-        'document_overrides' => ['production_methods'],
-    ]);
+    Item::factory()
+        ->for(Document::factory()->published()->create([
+            'production_methods' => [ProductionMethod::Painting],
+        ]))
+        ->create();
 
     app(ItemRepository::class)->refreshIndex();
 
@@ -178,18 +183,9 @@ it('can filter items by array property', function () {
 
 it('can sort items', function () {
     $items = [
-        Item::factory()->create([
-            'type' => ItemType::AudioRecording,
-            'document_overrides' => ['type'],
-        ]),
-        Item::factory()->create([
-            'type' => ItemType::Drawing,
-            'document_overrides' => ['type'],
-        ]),
-        Item::factory()->create([
-            'type' => ItemType::Map,
-            'document_overrides' => ['type'],
-        ]),
+        Item::factory()->for(Document::factory()->published()->create(['type' => ItemType::AudioRecording]))->create(),
+        Item::factory()->for(Document::factory()->published()->create(['type' => ItemType::Drawing]))->create(),
+        Item::factory()->for(Document::factory()->published()->create(['type' => ItemType::Map]))->create(),
     ];
 
     app(ItemRepository::class)->refreshIndex();
@@ -203,9 +199,9 @@ it('can sort items', function () {
 });
 
 it('can sort items by title using active locale keyword', function () {
-    $document1 = Document::factory()->create(['title' => ['en' => 'Zebra']]);
-    $document2 = Document::factory()->create(['title' => ['en' => 'Apple']]);
-    $document3 = Document::factory()->create(['title' => ['en' => 'Mango']]);
+    $document1 = Document::factory()->published()->create(['title' => ['en' => 'Zebra']]);
+    $document2 = Document::factory()->published()->create(['title' => ['en' => 'Apple']]);
+    $document3 = Document::factory()->published()->create(['title' => ['en' => 'Mango']]);
 
     $item1 = Item::factory()->for($document1)->create();
     $item2 = Item::factory()->for($document2)->create();
@@ -223,15 +219,17 @@ it('can filter items by belongsTo property', function (string $propertyKey, stri
     $matchingEntity = $factoryClass::factory()->create();
     $otherEntity = $factoryClass::factory()->create();
 
-    $matchingItem = Item::factory()->create([
-        "{$propertyKey}_id" => $matchingEntity->id,
-        'document_overrides' => [$propertyKey],
-    ]);
+    $matchingItem = Item::factory()
+        ->for(Document::factory()
+            ->published()
+            ->create(["{$propertyKey}_id" => $matchingEntity->id]))
+        ->create();
 
-    Item::factory()->create([
-        "{$propertyKey}_id" => $otherEntity->id,
-        'document_overrides' => [$propertyKey],
-    ]);
+    Item::factory()
+        ->for(Document::factory()
+            ->published()
+            ->create(["{$propertyKey}_id" => $otherEntity->id]))
+        ->create();
 
     app(ItemRepository::class)->refreshIndex();
 
@@ -252,16 +250,18 @@ it('can filter items by belongsToMany property', function (string $propertyKey, 
     $otherEntity = $factoryClass::factory()->create();
 
     $matchingItem = Item::factory()
-        ->hasAttached($matchingEntity, [], $relation)
-        ->create([
-            'document_overrides' => [$relation],
-        ]);
+        ->for(Document::factory()
+            ->published()
+            ->hasAttached($matchingEntity, [], $relation)
+            ->create())
+        ->create();
 
     Item::factory()
-        ->hasAttached($otherEntity, [], $relation)
-        ->create([
-            'document_overrides' => [$relation],
-        ]);
+        ->for(Document::factory()
+            ->published()
+            ->hasAttached($otherEntity, [], $relation)
+            ->create())
+        ->create();
 
     app(ItemRepository::class)->refreshIndex();
 
@@ -283,16 +283,20 @@ it('can filter items by originator', function () {
     $matchingPerson = Person::factory()->create();
     $otherPerson = Person::factory()->create();
 
-    $matchingItem = Item::factory()->create(['document_overrides' => ['originators']]);
-    ItemOriginator::factory()
-        ->for($matchingItem)
-        ->for($matchingPerson)
+    $matchingDocument = Document::factory()
+        ->published()
+        ->has(DocumentOriginator::factory()->for($matchingPerson), 'originators')
+        ->create();
+    $matchingItem = Item::factory()
+        ->for($matchingDocument)
         ->create();
 
-    $other = Item::factory()->create(['document_overrides' => ['originators']]);
-    ItemOriginator::factory()
-        ->for($other)
-        ->for($otherPerson)
+    $otherDocument = Document::factory()
+        ->published()
+        ->has(DocumentOriginator::factory()->for($otherPerson), 'originators')
+        ->create();
+    $otherItem = Item::factory()
+        ->for($otherDocument)
         ->create();
 
     app(ItemRepository::class)->refreshIndex();
@@ -311,11 +315,11 @@ it('can filter items by locality', function (string $propertyKey, string $factor
     $otherLocality = $factoryClass::factory()->create();
 
     $matchingItem = Item::factory()
-        ->for(Document::factory()->for($matchingLocality, 'locality'), 'document')
+        ->for(Document::factory()->published()->for($matchingLocality, 'locality'))
         ->create();
 
     Item::factory()
-        ->for(Document::factory()->for($otherLocality, 'locality'), 'document')
+        ->for(Document::factory()->published()->for($otherLocality, 'locality'))
         ->create();
 
     app(ItemRepository::class)->refreshIndex();
@@ -337,17 +341,17 @@ it('can filter items by locality', function (string $propertyKey, string $factor
 ]);
 
 it('can filter items by overlapping time period specifying only lower bound', function () {
-    $matching = Item::factory()->create([
+    $matchingDocument = Document::factory()->published()->create([
         'time_period_start' => '1950-12-31',
         'time_period_end' => '1950-12-31',
-        'document_overrides' => ['time_period_start', 'time_period_end'],
     ]);
+    $matchingItem = Item::factory()->for($matchingDocument)->create();
 
-    Item::factory()->create([
+    $otherDocument = Document::factory()->published()->create([
         'time_period_start' => '1800-01-01',
         'time_period_end' => '1850-01-01',
-        'document_overrides' => ['time_period_start', 'time_period_end'],
     ]);
+    $otherItem = Item::factory()->for($otherDocument)->create();
 
     app(ItemRepository::class)->refreshIndex();
 
@@ -359,21 +363,23 @@ it('can filter items by overlapping time period specifying only lower bound', fu
 
     $response->assertStatus(200)
         ->assertJsonCount(1, 'data')
-        ->assertJsonPath('data.0.id', $matching->identifier);
+        ->assertJsonPath('data.0.id', $matchingItem->identifier);
 });
 
 it('can filter items by overlapping time period specifying only upper bound', function () {
-    $matching = Item::factory()->create([
-        'time_period_start' => '1950-12-31',
-        'time_period_end' => '1950-12-31',
-        'document_overrides' => ['time_period_start', 'time_period_end'],
-    ]);
+    $matching = Item::factory()
+        ->for(Document::factory()->published()->create([
+            'time_period_start' => '1950-12-31',
+            'time_period_end' => '1950-12-31',
+        ]))
+        ->create();
 
-    Item::factory()->create([
-        'time_period_start' => '2000-01-01',
-        'time_period_end' => '2000-01-01',
-        'document_overrides' => ['time_period_start', 'time_period_end'],
-    ]);
+    Item::factory()
+        ->for(Document::factory()->published()->create([
+            'time_period_start' => '2000-01-01',
+            'time_period_end' => '2000-01-01',
+        ]))
+        ->create();
 
     app(ItemRepository::class)->refreshIndex();
 
@@ -389,17 +395,19 @@ it('can filter items by overlapping time period specifying only upper bound', fu
 });
 
 it('can filter items by overlapping time period when end date is null', function () {
-    $matching = Item::factory()->create([
-        'time_period_start' => '1950-12-31',
-        'time_period_end' => null,
-        'document_overrides' => ['time_period_start', 'time_period_end'],
-    ]);
+    $matching = Item::factory()
+        ->for(Document::factory()->published()->create([
+            'time_period_start' => '1950-12-31',
+            'time_period_end' => null,
+        ]))
+        ->create();
 
-    Item::factory()->create([
-        'time_period_start' => '1800-01-01',
-        'time_period_end' => '1850-01-01',
-        'document_overrides' => ['time_period_start', 'time_period_end'],
-    ]);
+    Item::factory()
+        ->for(Document::factory()->published()->create([
+            'time_period_start' => '1800-01-01',
+            'time_period_end' => '1850-01-01',
+        ]))
+        ->create();
 
     app(ItemRepository::class)->refreshIndex();
 
@@ -533,4 +541,22 @@ it('does not show first media in index when access rights are restricted and use
 
     $response->assertStatus(200);
     expect($response->json('data.0'))->not->toHaveKey('first_media');
+});
+
+it('does not list unpublished items in index', function () {
+    $itemOpen = Item::factory()
+        ->for(Document::factory()->published())
+        ->create();
+
+    Item::factory()
+        ->for(Document::factory()->published(false))
+        ->create();
+
+    app(ItemRepository::class)->refreshIndex();
+
+    $response = getJson(route('api.etno.items.index'));
+
+    $response->assertStatus(200)
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $itemOpen->identifier);
 });

--- a/app-modules/etno/tests/Feature/Api/ItemMapPointsTest.php
+++ b/app-modules/etno/tests/Feature/Api/ItemMapPointsTest.php
@@ -13,7 +13,7 @@ beforeEach(function () {
 
 it('includes newly created item with locality in map points', function () {
     $localityWithCoordinates = Location::factory()->withCoordinates()->create();
-    $document = Document::factory()->for($localityWithCoordinates, 'locality');
+    $document = Document::factory()->published()->for($localityWithCoordinates, 'locality');
     $item = Item::factory()->for($document, 'document')->create();
 
     getJson(route('api.etno.items.map-points'))
@@ -22,7 +22,7 @@ it('includes newly created item with locality in map points', function () {
 });
 
 it('does not include item without locality in map points', function () {
-    $document = Document::factory()->withoutLocality();
+    $document = Document::factory()->published()->withoutLocality();
     $item = Item::factory()->for($document, 'document')->create();
 
     $response = getJson(route('api.etno.items.map-points'));
@@ -32,22 +32,15 @@ it('does not include item without locality in map points', function () {
 
 it('updates map points when item locality is updated', function () {
     $localityWithCoordinates = Location::factory()->withCoordinates()->create();
-    $document = Document::factory()->for($localityWithCoordinates, 'locality');
+    $document = Document::factory()->published()->for($localityWithCoordinates, 'locality');
     $item = Item::factory()->for($document, 'document')->create();
 
     // fetch to populate cache
     getJson(route('api.etno.items.map-points'));
 
     $newLocalityWithCoordinates = Location::factory()->withCoordinates()->create();
-    $item->locality()->associate($newLocalityWithCoordinates);
-
-    $overrides = $item->document_overrides ?? [];
-    if (! in_array('locality', $overrides)) {
-        $overrides[] = 'locality';
-        $item->document_overrides = $overrides;
-    }
-
-    $item->save();
+    $item->document->locality()->associate($newLocalityWithCoordinates);
+    $item->document->save();
 
     $response = getJson(route('api.etno.items.map-points'));
 
@@ -58,7 +51,7 @@ it('updates map points when item locality is updated', function () {
 
 it('removes item from map points when item with locality is deleted', function () {
     $localityWithCoordinates = Location::factory()->withCoordinates()->create();
-    $document = Document::factory()->for($localityWithCoordinates, 'locality');
+    $document = Document::factory()->published()->for($localityWithCoordinates, 'locality');
     $item = Item::factory()->for($document, 'document')->create();
 
     getJson(route('api.etno.items.map-points'));
@@ -74,7 +67,7 @@ it('updates map points when locality coordinates are updated', function () {
         'latitude' => fake()->unique(reset: true)->latitude(),
         'longitude' => fake()->unique()->longitude(),
     ]);
-    $document = Document::factory()->for($locality, 'locality');
+    $document = Document::factory()->published()->for($locality, 'locality');
     $item = Item::factory()->for($document, 'document')->create();
 
     getJson(route('api.etno.items.map-points'));
@@ -96,7 +89,7 @@ it('updates map points when locality coordinates are updated', function () {
 
 it('removes item from map points when locality is deleted', function () {
     $locality = Location::factory()->withCoordinates()->create();
-    $document = Document::factory()->for($locality, 'locality');
+    $document = Document::factory()->published()->for($locality, 'locality');
     $item = Item::factory()->for($document, 'document')->create();
 
     getJson(route('api.etno.items.map-points'));
@@ -109,7 +102,7 @@ it('removes item from map points when locality is deleted', function () {
 
 it('includes item in map points when item with locality is restored', function () {
     $localityWithCoordinates = Location::factory()->withCoordinates()->create();
-    $document = Document::factory()->for($localityWithCoordinates, 'locality');
+    $document = Document::factory()->published()->for($localityWithCoordinates, 'locality');
     $item = Item::factory()->for($document, 'document')->create();
     $item->delete();
 
@@ -123,7 +116,7 @@ it('includes item in map points when item with locality is restored', function (
 
 it('does not include item in map points when document is deleted', function () {
     $localityWithCoordinates = Location::factory()->withCoordinates()->create();
-    $document = Document::factory()->for($localityWithCoordinates, 'locality');
+    $document = Document::factory()->published()->for($localityWithCoordinates, 'locality');
     $item = Item::factory()->for($document, 'document')->create();
 
     getJson(route('api.etno.items.map-points'));
@@ -136,14 +129,14 @@ it('does not include item in map points when document is deleted', function () {
 
 it('returns map points as a sequential array when items are filtered out', function () {
     $locality1 = Location::factory()->withCoordinates()->create();
-    $document1 = Document::factory()->for($locality1, 'locality');
+    $document1 = Document::factory()->published()->for($locality1, 'locality');
     $item1 = Item::factory()->for($document1, 'document')->create();
 
-    $document2 = Document::factory()->withoutLocality();
+    $document2 = Document::factory()->published()->withoutLocality();
     $item2 = Item::factory()->for($document2, 'document')->create();
 
     $locality3 = Location::factory()->withCoordinates()->create();
-    $document3 = Document::factory()->for($locality3, 'locality');
+    $document3 = Document::factory()->published()->for($locality3, 'locality');
     $item3 = Item::factory()->for($document3, 'document')->create();
 
     $response = getJson(route('api.etno.items.map-points'));
@@ -161,7 +154,7 @@ it('returns map points as a sequential array when items are filtered out', funct
 
 it('includes item in map points when document is restored', function () {
     $localityWithCoordinates = Location::factory()->withCoordinates()->create();
-    $document = Document::factory()->for($localityWithCoordinates, 'locality');
+    $document = Document::factory()->published()->for($localityWithCoordinates, 'locality');
     $item = Item::factory()->for($document, 'document')->create();
     $item->document->delete();
 
@@ -171,4 +164,13 @@ it('includes item in map points when document is restored', function () {
 
     $response = getJson(route('api.etno.items.map-points'));
     expect(collect($response->json('data'))->pluck('id'))->toContain($item->identifier);
+});
+
+it('does not include unpublished items in map points', function () {
+    $localityWithCoordinates = Location::factory()->withCoordinates()->create();
+    $document = Document::factory()->published(false)->for($localityWithCoordinates, 'locality');
+    $item = Item::factory()->for($document, 'document')->create();
+
+    $response = getJson(route('api.etno.items.map-points'));
+    expect(collect($response->json('data'))->pluck('id'))->not->toContain($item->identifier);
 });

--- a/app-modules/etno/tests/Feature/Api/ItemShowTest.php
+++ b/app-modules/etno/tests/Feature/Api/ItemShowTest.php
@@ -29,7 +29,8 @@ it('can show a complete item with all relations', function () {
 
     $response = getJson(route('api.etno.items.show', $item->identifier));
 
-    $document = $item->document;
+    $document = $item->document
+        ->load('originators.person');
 
     $response->assertStatus(200)
         ->assertJsonCount(2, 'data.authors')
@@ -37,7 +38,7 @@ it('can show a complete item with all relations', function () {
         ->assertJsonCount(2, 'data.originators')
         ->assertJsonCount(2, 'data.keywords')
         ->assertJsonCount(2, 'data.research_collections')
-        ->assertExactJsonStructure([
+        ->assertJsonStructure([
             'data' => [
                 'id',
                 'document_id',
@@ -292,9 +293,9 @@ it('shows media when access rights are restricted and user is authenticated', fu
         ->assertJsonCount(1, 'data.media.documents');
 });
 
-it('does not show media when access rights are closed and user is authenticated', function () {
+it('does not show media when access rights are embargoed and user is authenticated', function () {
     $item = Item::factory()->withTranscribedMedia()->create();
-    $item->document->update(['access_rights' => AccessRights::ClosedAccess]);
+    $item->document->update(['access_rights' => AccessRights::EmbargoedAccess]);
 
     $user = User::factory()->create();
 
@@ -302,4 +303,14 @@ it('does not show media when access rights are closed and user is authenticated'
 
     $response->assertStatus(200);
     expect($response->json('data'))->not->toHaveKey('media');
+});
+
+it('returns 404 for unpublished items', function () {
+    $item = Item::factory()
+        ->for(Document::factory()->published(false))
+        ->create();
+
+    $response = getJson(route('api.etno.items.show', $item->identifier));
+
+    $response->assertStatus(404);
 });

--- a/app-modules/etno/tests/Feature/Observers/DocumentObserverTest.php
+++ b/app-modules/etno/tests/Feature/Observers/DocumentObserverTest.php
@@ -8,7 +8,7 @@ use Metafori\Opensearch\Testing\RefreshIndices;
 uses(RefreshIndices::class);
 
 it('synchronizes item search indexing when a document is deleted and restored', function () {
-    $document = Document::factory()->create();
+    $document = Document::factory()->published()->create();
     $item = Item::factory()->for($document, 'document')->create();
 
     app(ItemRepository::class)->refreshIndex();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Items inherit document publication state; only published items are searchable and listed.

* **Bug Fixes**
  * Unpublished items excluded from search, API listings, map points, aggregations, and item detail (404).

* **Behavior / Indexing**
  * Indexing and map-point cache now respond to access-rights changes; originator edits update related document timestamps.

* **Tests**
  * Test suite expanded to cover published/unpublished document and indexing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->