### PR TITLE
chore(ci): pin gha hashes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
           --health-retries 10
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Install nixfmt
       run: |
@@ -50,7 +50,7 @@ jobs:
         chmod +x /usr/local/bin/nixfmt
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # master
       with:
         php-version: '8.5'
         extensions: ctype, curl, dom, fileinfo, filter, hash, mbstring, openssl, pcre, pdo, pdo_pgsql, session, tokenizer, xml
@@ -60,7 +60,7 @@ jobs:
       run: composer run setup
 
     - name: Run prek on all files (PHPStan, Laravel Pint, etc.)
-      uses: j178/prek-action@v1
+      uses: j178/prek-action@0bb87d7f00b0c99306c8bcb8b8beba1eb581c037 # v1.1.1
       with:
         prek-version: '0.3.4'
 

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+# files:
+#   - pattern: action.yaml
+#   - pattern: */action.yaml
+
+ignore_actions:
+# - name: slsa-framework/slsa-github-generator/\.github/workflows/generator_generic_slsa3\.yml
+#   ref: v\d+\.\d+\.\d+
+# - name: actions/.*
+#   ref: main
+# - name: suzuki-shunsuke/.*
+#   ref: release-.*


### PR DESCRIPTION
This lowers supply chain attacks vector a tiny bit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated CI/CD workflow configuration to pin specific versions of build automation actions, improving stability and reproducibility across workflow runs
* Added configuration file for managing action version pinning settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->