### PR TITLE
chore: configurable trusted proxies

### DIFF
--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'proxies' => env('TRUSTED_PROXIES'),
+];


### PR DESCRIPTION
laravel expects trusted proxies at `config('trustedproxy.proxies')`