### PR TITLE
feat(etno): add media type to item api

### DIFF
--- a/app-modules/etno/src/Http/Resources/ItemResource.php
+++ b/app-modules/etno/src/Http/Resources/ItemResource.php
@@ -82,6 +82,8 @@ class ItemResource extends JsonResource
             'keywords' => KeywordResource::collection($this->whenLoaded('keywords')),
             'research_collections' => ResearchCollectionResource::collection($this->whenLoaded('researchCollections')),
             'document_id' => $this->document_id,
+            /** @var MediaType|null */
+            'media_type' => $this->whenLoaded('firstMedia', fn () => $this->firstMedia ? MediaType::tryFrom($this->firstMedia->collection_name) : null),
             'first_media' => $this->whenLoaded('firstMedia', fn () => $this->when(
                 Gate::allows('viewMedia', $this->resource),
                 fn () => new MediaResource($this->firstMedia)

--- a/app-modules/etno/tests/Feature/Api/ItemIndexTest.php
+++ b/app-modules/etno/tests/Feature/Api/ItemIndexTest.php
@@ -15,6 +15,7 @@ use Metafori\Etno\Enums\AccessRights;
 use Metafori\Etno\Enums\AccrualMethod;
 use Metafori\Etno\Enums\CollectionMethod;
 use Metafori\Etno\Enums\ItemType;
+use Metafori\Etno\Enums\MediaType;
 use Metafori\Etno\Enums\ProductionMethod;
 use Metafori\Etno\Models\Document;
 use Metafori\Etno\Models\DocumentOriginator;
@@ -79,6 +80,7 @@ it('can list items', function () {
                         'id',
                         'name',
                     ],
+                    'media_type',
                 ],
             ],
             'meta',
@@ -529,6 +531,7 @@ it('shows first media in index when access rights are open access', function () 
             'name', 'file_name', 'url', 'transcript',
         ]]]]);
     expect($response->json('data.0.first_media'))->not->toBeNull();
+    expect($response->json('data.0.media_type'))->toBe(MediaType::Document->value);
 });
 
 it('does not show first media in index when access rights are restricted and user is unauthenticated', function () {
@@ -541,6 +544,7 @@ it('does not show first media in index when access rights are restricted and use
 
     $response->assertStatus(200);
     expect($response->json('data.0'))->not->toHaveKey('first_media');
+    expect($response->json('data.0.media_type'))->toBe(MediaType::Document->value);
 });
 
 it('does not list unpublished items in index', function () {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `media_type` field to item API responses, indicating the type of associated media.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->