### PR TITLE
feat(etno): add item media in background

### DIFF
--- a/app-modules/etno/src/Filament/Concerns/HandlesMediaUploads.php
+++ b/app-modules/etno/src/Filament/Concerns/HandlesMediaUploads.php
@@ -4,11 +4,11 @@ namespace Metafori\Etno\Filament\Concerns;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
-use Livewire\Features\SupportFileUploads\FileUploadConfiguration;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Metafori\Etno\Enums\TranscriptFormat;
+use Metafori\Etno\Jobs\ProcessItemMediaUpload;
 use Metafori\Etno\Models\Item;
-use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Metafori\Etno\Repositories\ItemRepository;
 
 trait HandlesMediaUploads
 {
@@ -87,14 +87,16 @@ trait HandlesMediaUploads
         return $items;
     }
 
-    protected function addItemMedia(Item $item, TemporaryUploadedFile $file, array $customProperties): Media
+    protected function addItemMedia(Item $item, TemporaryUploadedFile $file, array $customProperties): void
     {
-        $collection = Item::getMediaCollectionName($file->getMimeType()) ?? throw new \InvalidArgumentException("Unsupported mime type: {$file->getMimeType()}");
+        ProcessItemMediaUpload::dispatch(
+            $item,
+            $file->getClientOriginalPath(),
+            $file->getClientOriginalName(),
+            $file->getMimeType(),
+            $customProperties
+        );
 
-        return $item->addMediaFromDisk($file->getClientOriginalPath(), FileUploadConfiguration::disk())
-            ->usingName(File::name($file->getClientOriginalName()))
-            ->usingFileName($file->getClientOriginalName())
-            ->withCustomProperties($customProperties)
-            ->toMediaCollection($collection);
+        app(ItemRepository::class)->incrementProcessingMediaCount($item);
     }
 }

--- a/app-modules/etno/src/Filament/Resources/Items/RelationManagers/MediaRelationManager.php
+++ b/app-modules/etno/src/Filament/Resources/Items/RelationManagers/MediaRelationManager.php
@@ -11,6 +11,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Metafori\Etno\Enums\TranscriptFormat;
 use Metafori\Etno\Filament\Resources\Items\Schemas\MediaForm;
+use Metafori\Etno\Repositories\ItemRepository;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class MediaRelationManager extends RelationManager
@@ -25,6 +26,18 @@ class MediaRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         return $table
+            ->poll(function (RelationManager $livewire, ItemRepository $itemRepository) {
+                $count = $itemRepository->getProcessingMediaCount($livewire->getOwnerRecord());
+
+                return $count > 0 ? '2s' : null;
+            })
+            ->description(function (RelationManager $livewire, ItemRepository $itemRepository) {
+                $count = $itemRepository->getProcessingMediaCount($livewire->getOwnerRecord());
+
+                return $count > 0
+                    ? trans_choice(':count media file is currently being processed in the background.|:count media files are currently being processed in the background.', $count)
+                    : null;
+            })
             ->columns([
                 TextColumn::make('name')
                     ->searchable()

--- a/app-modules/etno/src/Jobs/ProcessItemMediaUpload.php
+++ b/app-modules/etno/src/Jobs/ProcessItemMediaUpload.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Metafori\Etno\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\FailOnException;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\File;
+use InvalidArgumentException;
+use Livewire\Features\SupportFileUploads\FileUploadConfiguration;
+use Metafori\Etno\Models\Item;
+use Metafori\Etno\Repositories\ItemRepository;
+
+class ProcessItemMediaUpload implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public Item $item,
+        public string $filePath,
+        public string $originalName,
+        public string $mimeType,
+        public array $customProperties = []
+    ) {}
+
+    public function handle(ItemRepository $itemRepository): void
+    {
+        $collection = Item::getMediaCollectionName($this->mimeType) ?? throw new InvalidArgumentException("Unsupported mime type: {$this->mimeType}");
+
+        $this->item->addMediaFromDisk($this->filePath, FileUploadConfiguration::disk())
+            ->usingName(File::name($this->originalName))
+            ->usingFileName($this->originalName)
+            ->withCustomProperties($this->customProperties)
+            ->toMediaCollection($collection);
+
+        $itemRepository->decrementProcessingMediaCount($this->item);
+    }
+
+    public function middleware(): array
+    {
+        return [
+            new FailOnException([InvalidArgumentException::class]),
+        ];
+    }
+}

--- a/app-modules/etno/src/Repositories/ItemRepository.php
+++ b/app-modules/etno/src/Repositories/ItemRepository.php
@@ -260,4 +260,24 @@ class ItemRepository
             'lte' => \is_numeric($to) ? "{$to}||/y" : $to,
         ]);
     }
+
+    public function incrementProcessingMediaCount(Item $item): void
+    {
+        Cache::increment($this->getProcessingMediaCacheKey($item));
+    }
+
+    public function decrementProcessingMediaCount(Item $item): void
+    {
+        Cache::decrement($this->getProcessingMediaCacheKey($item));
+    }
+
+    public function getProcessingMediaCount(Item $item): int
+    {
+        return Cache::get($this->getProcessingMediaCacheKey($item), 0);
+    }
+
+    protected function getProcessingMediaCacheKey(Item $item): string
+    {
+        return "etno.item.{$item->id}.processing_media";
+    }
 }

--- a/app-modules/etno/tests/Feature/Filament/Actions/Items/UploadMediaTest.php
+++ b/app-modules/etno/tests/Feature/Filament/Actions/Items/UploadMediaTest.php
@@ -4,9 +4,13 @@ namespace Metafori\Etno\Tests\Feature\Filament\Actions\Items;
 
 use Filament\Actions\Testing\TestAction;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Queue;
 use Metafori\Core\Models\User;
 use Metafori\Etno\Filament\Resources\Items\ItemResource;
 use Metafori\Etno\Filament\Resources\Items\Pages\EditItem;
+use Metafori\Etno\Filament\Resources\Items\RelationManagers\MediaRelationManager;
+use Metafori\Etno\Jobs\ProcessItemMediaUpload;
 use Metafori\Etno\Models\Item;
 
 use function Pest\Laravel\actingAs;
@@ -17,6 +21,8 @@ beforeEach(function () {
 });
 
 it('uploads media files and assigns custom properties', function () {
+    Queue::fake();
+
     $item = Item::factory()->create();
 
     $image = UploadedFile::fake()->create('test.jpg', 100, 'image/jpeg');
@@ -39,11 +45,16 @@ it('uploads media files and assigns custom properties', function () {
             'relation' => 'media',
         ]));
 
-    $media = $item->media->first();
-    expect($media)->not->toBeNull()
-        ->and($media->name)->toBe('test')
-        ->and($media->file_name)->toBe('test.jpg')
-        ->and($media->getCustomProperty('transcripts.txt'))->toBe('text');
+    Queue::assertPushed(
+        ProcessItemMediaUpload::class,
+        fn ($job) => $job->item->id === $item->id
+            && Arr::get($job->customProperties, 'transcripts.txt') === 'text'
+    );
+
+    livewire(MediaRelationManager::class, [
+        'ownerRecord' => $item,
+        'pageClass' => EditItem::class,
+    ])->assertSee('1 media file is currently being processed in the background.');
 });
 
 it('cannot assign media files of various mime types to one item', function () {

--- a/app-modules/etno/tests/Feature/Filament/Resources/Items/Pages/CreateItemsFromFilesTest.php
+++ b/app-modules/etno/tests/Feature/Filament/Resources/Items/Pages/CreateItemsFromFilesTest.php
@@ -3,8 +3,11 @@
 namespace Metafori\Etno\Tests\Feature\Filament\Resources\Items\Pages;
 
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Queue;
 use Metafori\Core\Models\User;
 use Metafori\Etno\Filament\Resources\Items\Pages\CreateItemsFromFiles;
+use Metafori\Etno\Jobs\ProcessItemMediaUpload;
 use Metafori\Etno\Models\Document;
 
 use function Pest\Laravel\actingAs;
@@ -15,6 +18,8 @@ beforeEach(function () {
 });
 
 it('extracts transcripts, syncs items and applies transcripts', function () {
+    Queue::fake();
+
     $document = Document::factory()->create(['id' => 'AA000001']);
 
     $image1 = UploadedFile::fake()->create('test1.jpg', 100, 'image/jpeg');
@@ -37,10 +42,15 @@ it('extracts transcripts, syncs items and applies transcripts', function () {
     $item1 = $items->firstWhere('identifier', 'AA000001:a');
     $item2 = $items->firstWhere('identifier', 'AA000001:b');
 
-    expect($item1->load('media')->media)->toHaveCount(1);
-    expect($item1->media->first()->custom_properties['transcripts']['txt'])->toBe('transcript one text');
-    expect($item2->load('media')->media)->toHaveCount(1);
-    expect($item2->media->first()->custom_properties['transcripts']['txt'])->toBeNull();
+    Queue::assertPushed(
+        ProcessItemMediaUpload::class,
+        fn ($job) => $job->item->id === $item1->id && Arr::get($job->customProperties, 'transcripts.txt') === 'transcript one text'
+    );
+
+    Queue::assertPushed(
+        ProcessItemMediaUpload::class,
+        fn ($job) => $job->item->id === $item2->id && Arr::get($job->customProperties, 'transcripts.txt') === null
+    );
 });
 
 it('can reorder items by file name', function () {

--- a/app-modules/etno/tests/Feature/Jobs/ProcessItemMediaUploadTest.php
+++ b/app-modules/etno/tests/Feature/Jobs/ProcessItemMediaUploadTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Metafori\Etno\Tests\Feature\Jobs;
+
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Features\SupportFileUploads\FileUploadConfiguration;
+use Metafori\Etno\Jobs\ProcessItemMediaUpload;
+use Metafori\Etno\Models\Item;
+use Metafori\Etno\Repositories\ItemRepository;
+
+it('processes item media upload and decrements cache count', function () {
+    Queue::fake();
+    Storage::fake(FileUploadConfiguration::disk());
+
+    $item = Item::factory()->create();
+    $repository = app(ItemRepository::class);
+
+    $repository->incrementProcessingMediaCount($item);
+
+    $fileName = 'test-file.jpg';
+    Storage::disk(FileUploadConfiguration::disk())->put($fileName, 'fake image content');
+
+    $job = new ProcessItemMediaUpload(
+        item: $item,
+        filePath: $fileName,
+        originalName: 'test.jpg',
+        mimeType: 'image/jpeg',
+        customProperties: ['transcripts' => ['txt' => 'text']]
+    );
+
+    $job->handle($repository);
+
+    $media = $item->fresh()->media->first();
+
+    expect($media)->not->toBeNull()
+        ->and($media->name)->toBe('test')
+        ->and($media->file_name)->toBe('test.jpg')
+        ->and($media->getCustomProperty('transcripts.txt'))->toBe('text');
+
+    expect($repository->getProcessingMediaCount($item))->toBe(0);
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media uploads now queue for background processing.
  * UI shows a live processing indicator with periodic refresh while uploads are active.

* **Bug Fixes / Reliability**
  * Processing counters ensure upload state is tracked and cleared after work completes.

* **Tests**
  * Added and updated tests to validate background media processing and UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->