### PR TITLE
fix(etno): init processing media count

### DIFF
--- a/app-modules/etno/src/Repositories/ItemRepository.php
+++ b/app-modules/etno/src/Repositories/ItemRepository.php
@@ -263,7 +263,11 @@ class ItemRepository
 
     public function incrementProcessingMediaCount(Item $item): void
     {
-        Cache::increment($this->getProcessingMediaCacheKey($item));
+        $key = $this->getProcessingMediaCacheKey($item);
+
+        if (! Cache::add($key, 1)) {
+            Cache::increment($key);
+        }
     }
 
     public function decrementProcessingMediaCount(Item $item): void


### PR DESCRIPTION
In database cache driver the counter was never incremented

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache handling for media processing by ensuring proper initialization of tracking data when entries don't exist, enhancing reliability of media workflow operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->