### PR TITLE
fix(core): login 403 error response when request is not stateful

### DIFF
--- a/app-modules/core/src/Http/Controllers/Api/AuthController.php
+++ b/app-modules/core/src/Http/Controllers/Api/AuthController.php
@@ -13,6 +13,10 @@ class AuthController extends Controller
 {
     public function login(Request $request): Response|JsonResponse
     {
+        if (! $request->hasSession()) {
+            abort(403);
+        }
+
         $credentials = $request->validate([
             'email' => ['required', 'string', 'email'],
             'password' => ['required', 'string'],

--- a/app-modules/core/tests/Feature/Api/LoginTest.php
+++ b/app-modules/core/tests/Feature/Api/LoginTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Metafori\Core\Models\User;
-use Symfony\Component\HttpFoundation\Response;
 
 use function Pest\Laravel\postJson;
 
@@ -19,7 +18,7 @@ test('no password returns unprocessable entity response', function () {
 
     postJson(route('api.login'), [
         'email' => $user->email,
-    ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    ])->assertUnprocessable();
 });
 
 test('empty password returns unprocessable entity response', function () {
@@ -28,7 +27,7 @@ test('empty password returns unprocessable entity response', function () {
     postJson(route('api.login'), [
         'email' => $user->email,
         'password' => '',
-    ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    ])->assertUnprocessable();
 });
 
 test('wrong password returns unprocessable entity response', function () {
@@ -37,7 +36,7 @@ test('wrong password returns unprocessable entity response', function () {
     postJson(route('api.login'), [
         'email' => $user->email,
         'password' => 'wrong-password',
-    ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    ])->assertUnprocessable();
 });
 
 test('login requests are throttled after 5 attempts', function () {
@@ -47,11 +46,22 @@ test('login requests are throttled after 5 attempts', function () {
         postJson($url, [
             'email' => 'test@example.com',
             'password' => 'password',
-        ])->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+        ])->assertUnprocessable();
     }
 
     postJson($url, [
         'email' => 'test@example.com',
         'password' => 'password',
-    ])->assertStatus(Response::HTTP_TOO_MANY_REQUESTS);
+    ])->assertTooManyRequests();
+});
+
+test('stateless login requests are forbidden', function () {
+    $this->withoutHeader('referer');
+
+    $user = User::factory()->create();
+
+    postJson(route('api.login'), [
+        'email' => $user->email,
+        'password' => 'password',
+    ])->assertForbidden();
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Login API now validates session requirements and request context, returning HTTP 403 Forbidden for requests that lack these parameters before credential verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->