### PR TITLE
fix(core): use web guard for auth check

### DIFF
--- a/app-modules/core/src/Http/Middleware/IsAuthenticated.php
+++ b/app-modules/core/src/Http/Middleware/IsAuthenticated.php
@@ -4,6 +4,7 @@ namespace Metafori\Core\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpFoundation\Response;
 
 class IsAuthenticated
@@ -17,7 +18,7 @@ class IsAuthenticated
     {
         $response = $next($request);
 
-        if (auth()->check()) {
+        if (Auth::guard('web')->check()) {
             $response->headers->set('X-Is-Authenticated', 'true');
         }
 

--- a/app-modules/core/tests/Feature/Api/IsAuthenticatedTest.php
+++ b/app-modules/core/tests/Feature/Api/IsAuthenticatedTest.php
@@ -13,7 +13,7 @@ beforeEach(function () {
 it('does not add X-Is-Authenticated header for guests', function () {
     $response = get('/api/test-auth');
 
-    $response->assertStatus(200);
+    $response->assertOk();
     $response->assertHeaderMissing('X-Is-Authenticated');
 });
 
@@ -22,6 +22,15 @@ it('adds X-Is-Authenticated header for authenticated users', function () {
 
     $response = actingAs($user)->get('/api/test-auth');
 
-    $response->assertStatus(200);
+    $response->assertOk();
     $response->assertHeader('X-Is-Authenticated', 'true');
+});
+
+it('does not add X-Is-Authenticated header after logout', function () {
+    $user = User::factory()->create();
+
+    $response = actingAs($user)->post('/api/logout');
+
+    $response->assertNoContent();
+    $response->assertHeaderMissing('X-Is-Authenticated');
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication middleware to more reliably detect web-session authentication and correctly set the authenticated response header only when a session is active.

* **Tests**
  * Updated tests to modern assertions and added a new test verifying logout returns no content and removes the authenticated response header.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/metafori-studio/collection-toolbox-backend/pull/153)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->