### PR TITLE
[OGL-1570] fix(etno): invalidate map points cache when locality is inherited

### DIFF
--- a/app-modules/etno/src/Observers/ItemObserver.php
+++ b/app-modules/etno/src/Observers/ItemObserver.php
@@ -11,7 +11,7 @@ class ItemObserver
 
     public function created(Item $item): void
     {
-        if ($item->locality_id !== null) {
+        if ($item->resolveInheritableAttribute('locality') !== null) {
             $this->repository->invalidateMapPointsCache();
         }
     }
@@ -25,14 +25,14 @@ class ItemObserver
 
     public function deleted(Item $item): void
     {
-        if ($item->locality_id !== null) {
+        if ($item->resolveInheritableAttribute('locality') !== null) {
             $this->repository->invalidateMapPointsCache();
         }
     }
 
     public function restored(Item $item): void
     {
-        if ($item->locality_id !== null) {
+        if ($item->resolveInheritableAttribute('locality') !== null) {
             $this->repository->invalidateMapPointsCache();
         }
     }

--- a/app-modules/etno/tests/Feature/Api/ItemMapPointsTest.php
+++ b/app-modules/etno/tests/Feature/Api/ItemMapPointsTest.php
@@ -21,6 +21,24 @@ it('includes newly created item with locality in map points', function () {
         ->assertJsonFragment(['id' => $item->identifier]);
 });
 
+it('invalidates cache when item is created inheriting document locality', function () {
+    $localityWithCoordinates = Location::factory()->withCoordinates()->create();
+    $document = Document::factory()->published()->for($localityWithCoordinates, 'locality');
+
+    getJson(route('api.etno.items.map-points'))
+        ->assertStatus(200);
+
+    $item = Item::factory()->for($document, 'document')->create([
+        'locality_id' => null,
+        'locality_type' => null,
+        'document_overrides' => [],
+    ]);
+
+    getJson(route('api.etno.items.map-points'))
+        ->assertStatus(200)
+        ->assertJsonFragment(['id' => $item->identifier]);
+});
+
 it('does not include item without locality in map points', function () {
     $document = Document::factory()->published()->withoutLocality();
     $item = Item::factory()->for($document, 'document')->create();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed map cache invalidation so items that inherit location from related records correctly trigger cache refresh on create/delete/restore.

* **Tests**
  * Added feature test to verify map cache is refreshed when an item inherits locality from a related record.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->