### PR TITLE
[OGL-1571] feat(etno): add document show api

### DIFF
--- a/app-modules/etno/routes/api.php
+++ b/app-modules/etno/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Metafori\Etno\Http\Controllers\Api\DocumentController;
 use Metafori\Etno\Http\Controllers\Api\ItemController;
 use Metafori\Etno\Http\Controllers\Api\TranslationController;
 
@@ -13,6 +14,9 @@ Route::prefix('api/etno')->middleware(['api'])->name('api.etno.')->group(functio
         ->name('items.map-points');
     Route::apiResource('items', ItemController::class)->only([
         'index',
+        'show',
+    ]);
+    Route::apiResource('documents', DocumentController::class)->only([
         'show',
     ]);
     Route::get('translations', [TranslationController::class, 'index'])

--- a/app-modules/etno/src/Http/Controllers/Api/DocumentController.php
+++ b/app-modules/etno/src/Http/Controllers/Api/DocumentController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Metafori\Etno\Http\Controllers\Api;
+
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Metafori\Etno\Http\Resources\DocumentResource;
+use Metafori\Etno\Models\Document;
+use Metafori\Etno\Repositories\DocumentRepository;
+
+class DocumentController
+{
+    public function __construct(
+        private readonly DocumentRepository $repository,
+    ) {}
+
+    /**
+     * @throws ModelNotFoundException<Document>
+     */
+    public function show(string $id): DocumentResource
+    {
+        $document = $this->repository->findOrFail($id);
+
+        return new DocumentResource($document);
+    }
+}

--- a/app-modules/etno/src/Models/Document.php
+++ b/app-modules/etno/src/Models/Document.php
@@ -2,6 +2,7 @@
 
 namespace Metafori\Etno\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,10 +10,16 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Metafori\Core\Models\District;
 use Metafori\Core\Models\Keyword;
+use Metafori\Core\Models\Location;
+use Metafori\Core\Models\Municipality;
+use Metafori\Core\Models\MunicipalityPart;
 use Metafori\Core\Models\Organization;
 use Metafori\Core\Models\Person;
+use Metafori\Core\Models\Region;
 use Metafori\Etno\Database\Factories\DocumentFactory;
+use Metafori\Etno\Enums\AccessRights;
 use Metafori\Etno\Models\Concerns\HasDocumentMetadata;
 use Stringable;
 
@@ -99,6 +106,44 @@ class Document extends Model implements Stringable
     public static function incrementSuffix(string $suffix): string
     {
         return str_increment($suffix);
+    }
+
+    public function scopePublished(Builder $query): void
+    {
+        $query->whereIn('access_rights', AccessRights::published());
+    }
+
+    public static function relations(): array
+    {
+        return [
+            'institution',
+            'project',
+            'authors',
+            'researchers',
+            'originators.person',
+            'keywords',
+            'researchCollections',
+            ...self::localityRelations(),
+        ];
+    }
+
+    public static function localityRelations(): array
+    {
+        $morphWith = [
+            Region::class => ['country'],
+            District::class => ['region.country'],
+            Municipality::class => ['district.region.country'],
+            MunicipalityPart::class => ['municipality.district.region.country'],
+        ];
+
+        return [
+            'locality' => fn (MorphTo $morphTo) => $morphTo->morphWith([
+                ...$morphWith,
+                Location::class => [
+                    'parent' => fn (MorphTo $morphTo) => $morphTo->morphWith($morphWith),
+                ],
+            ]),
+        ];
     }
 
     public function __toString(): string

--- a/app-modules/etno/src/Models/Item.php
+++ b/app-modules/etno/src/Models/Item.php
@@ -247,35 +247,7 @@ class Item extends Model implements HasMedia, Inheritable
 
     public static function relations(): array
     {
-        return self::documentRelations([
-            'institution',
-            'project',
-            'authors',
-            'researchers',
-            'originators.person',
-            'keywords',
-            'researchCollections',
-            ...self::localityRelations(),
-        ]);
-    }
-
-    public static function localityRelations(): array
-    {
-        $morphWith = [
-            Region::class => ['country'],
-            District::class => ['region.country'],
-            Municipality::class => ['district.region.country'],
-            MunicipalityPart::class => ['municipality.district.region.country'],
-        ];
-
-        return [
-            'locality' => fn (MorphTo $morphTo) => $morphTo->morphWith([
-                ...$morphWith,
-                Location::class => [
-                    'parent' => fn (MorphTo $morphTo) => $morphTo->morphWith($morphWith),
-                ],
-            ]),
-        ];
+        return self::documentRelations(Document::relations());
     }
 
     public static function documentRelations(array $with, ?\Closure $callback = null): array
@@ -308,7 +280,7 @@ class Item extends Model implements HasMedia, Inheritable
             })->orWhere(function (Builder $q) {
                 $q->whereJsonDoesntContain('etno_items.document_overrides', 'access_rights')
                     ->whereHas('document', function (Builder $dq) {
-                        $dq->whereIn('etno_documents.access_rights', AccessRights::published());
+                        $dq->published();
                     });
             });
         });

--- a/app-modules/etno/src/Repositories/DocumentRepository.php
+++ b/app-modules/etno/src/Repositories/DocumentRepository.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Metafori\Etno\Repositories;
+
+use Metafori\Etno\Models\Document;
+
+class DocumentRepository
+{
+    public function findOrFail(string $id): Document
+    {
+        return Document::query()
+            ->published()
+            ->with(Document::relations())
+            ->findOrFail($id);
+    }
+}

--- a/app-modules/etno/src/Repositories/ItemRepository.php
+++ b/app-modules/etno/src/Repositories/ItemRepository.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
+use Metafori\Etno\Models\Document;
 use Metafori\Etno\Models\Item;
 use Metafori\Etno\Support\FacetMetadata;
 use OpenSearch\Client;
@@ -60,7 +61,7 @@ class ItemRepository
                     'authors',
                     'researchers',
                     'originators.person',
-                    ...Item::localityRelations(),
+                    ...Document::localityRelations(),
                 ]),
             ]);
         });
@@ -118,7 +119,7 @@ class ItemRepository
                     'authors',
                     'researchers',
                     'originators.person',
-                    ...Item::localityRelations(),
+                    ...Document::localityRelations(),
                 ]),
             ]);
         });

--- a/app-modules/etno/tests/Feature/Api/DocumentShowTest.php
+++ b/app-modules/etno/tests/Feature/Api/DocumentShowTest.php
@@ -1,0 +1,202 @@
+<?php
+
+use Metafori\Core\Models\MunicipalityPart;
+use Metafori\Etno\Enums\ProductionMethod;
+use Metafori\Etno\Models\Document;
+
+use function Pest\Laravel\getJson;
+
+it('can show a complete document with all relations', function () {
+    $document = Document::factory()
+        ->published()
+        ->hasAuthors(2)
+        ->hasResearchers(2)
+        ->hasKeywords(2)
+        ->hasResearchCollections(2)
+        ->hasOriginators(2)
+        ->for(MunicipalityPart::factory(), 'locality')
+        ->create();
+
+    $response = getJson(route('api.etno.documents.show', $document->id));
+
+    $document->load('originators.person');
+
+    $response->assertStatus(200)
+        ->assertJsonCount(2, 'data.authors')
+        ->assertJsonCount(2, 'data.researchers')
+        ->assertJsonCount(2, 'data.originators')
+        ->assertJsonCount(2, 'data.keywords')
+        ->assertJsonCount(2, 'data.research_collections')
+        ->assertJsonStructure([
+            'data' => [
+                'id',
+                'doi',
+                'title',
+                'subtitle',
+                'abstract',
+                'general_note',
+                'terms_of_use',
+                'location_note',
+                'content_note',
+                'technical_note',
+                'type',
+                'language',
+                'accrual_method',
+                'collection_method',
+                'access_rights',
+                'license',
+                'production_methods',
+                'time_period_start',
+                'time_period_end',
+                'time_period_settings',
+                'submission_date_start',
+                'submission_date_end',
+                'submission_date_settings',
+                'publication_date_start',
+                'publication_date_end',
+                'publication_date_settings',
+                'institution' => [
+                    'id',
+                    'name',
+                    'ror_id',
+                ],
+                'project' => [
+                    'id',
+                    'title',
+                ],
+                'locality' => [
+                    'id',
+                    'name',
+                    'municipality' => [
+                        'id',
+                        'name',
+                        'district' => [
+                            'id',
+                            'name',
+                            'region' => [
+                                'id',
+                                'name',
+                                'country' => [
+                                    'id',
+                                    'name',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'authors' => [
+                    '*' => [
+                        'id',
+                        'given_name',
+                        'family_name',
+                        'display_name',
+                        'orcid',
+                    ],
+                ],
+                'researchers' => [
+                    '*' => [
+                        'id',
+                        'given_name',
+                        'family_name',
+                        'display_name',
+                        'orcid',
+                    ],
+                ],
+                'originators' => [
+                    '*' => [
+                        'id',
+                        'label',
+                        'person' => [
+                            'id',
+                            'given_name',
+                            'family_name',
+                            'display_name',
+                            'orcid',
+                        ],
+                    ],
+                ],
+                'keywords' => [
+                    '*' => [
+                        'id',
+                        'name',
+                    ],
+                ],
+                'research_collections' => [
+                    '*' => [
+                        'id',
+                        'title',
+                    ],
+                ],
+                'extents' => [
+                    '*' => [
+                        'value',
+                        'unit',
+                    ],
+                ],
+            ],
+        ])
+        ->assertJson([
+            'data' => [
+                'id' => $document->id,
+                'doi' => $document->doi,
+                'title' => $document->title,
+                'subtitle' => $document->subtitle,
+                'abstract' => $document->abstract,
+                'general_note' => $document->general_note,
+                'terms_of_use' => $document->terms_of_use,
+                'location_note' => $document->location_note,
+                'content_note' => $document->content_note,
+                'technical_note' => $document->technical_note,
+                'type' => $document->type?->value,
+                'extents' => collect($document->extents)->toArray(),
+                'language' => $document->language?->value,
+                'accrual_method' => $document->accrual_method?->value,
+                'collection_method' => $document->collection_method?->value,
+                'access_rights' => $document->access_rights?->value,
+                'license' => $document->license?->value,
+                'production_methods' => collect($document->production_methods)
+                    ->map(fn (ProductionMethod $method) => $method->value)
+                    ->toArray(),
+                'institution' => [
+                    'id' => $document->institution->id,
+                    'name' => $document->institution->name,
+                    'ror_id' => $document->institution->ror_id,
+                ],
+                'project' => [
+                    'id' => $document->project->id,
+                    'title' => $document->project->title,
+                ],
+                'locality' => [
+                    'id' => $document->locality->id,
+                    'name' => $document->locality->name,
+                ],
+                'originators' => $document->originators->map(fn ($originator) => [
+                    'id' => $originator->id,
+                    'label' => $originator->label,
+                    'person' => [
+                        'id' => $originator->person->id,
+                        'given_name' => $originator->person->given_name,
+                        'family_name' => $originator->person->family_name,
+                        'display_name' => $originator->person->display_name,
+                        'orcid' => $originator->person->orcid,
+                    ],
+                ])->toArray(),
+            ],
+        ]);
+});
+
+it('returns 404 for non-existent document', function () {
+    $response = getJson(route('api.etno.documents.show', 'invalid-id'));
+
+    $response->assertStatus(404);
+});
+
+it('returns 404 for unpublished document', function () {
+    $document = Document::factory()
+        ->published(false)
+        ->create();
+
+    $response = getJson(route('api.etno.documents.show', $document->id));
+
+    $response->assertStatus(404);
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a new API endpoint for retrieving individual published documents with complete related information (authors, keywords, research collections, and location details)
* The endpoint returns 404 when requesting non-existent or unpublished documents

## Tests
* Added comprehensive test coverage for the new document retrieval endpoint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->