### PR TITLE
feat(nix): split modules

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,27 +43,28 @@
       },
       "locked": {
         "dir": "nix",
-        "lastModified": 1779536930,
-        "narHash": "sha256-P/H+bGVMYv4Oa5uNbrP5PC6BARhwU5lG/Xtj7e/aTu4=",
-        "ref": "refs/heads/main",
-        "rev": "7edac7d4631307b85a89ed9e52fd85af51f4c44f",
-        "revCount": 136,
+        "lastModified": 1781129808,
+        "narHash": "sha256-M7xAcqKDtEdnwWKVmuAAsYVQIxC6itShz/BZLC4hJuM=",
+        "ref": "nix-split-modules",
+        "rev": "5cbddcf54beb2857ea591075d755a0b27842539b",
+        "revCount": 141,
         "type": "git",
         "url": "ssh://git@github.com/metafori-studio/infra.git"
       },
       "original": {
         "dir": "nix",
+        "ref": "nix-split-modules",
         "type": "git",
         "url": "ssh://git@github.com/metafori-studio/infra.git"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {
@@ -75,11 +76,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
       },
       "locked": {
         "dir": "nix",
-        "lastModified": 1781129808,
-        "narHash": "sha256-M7xAcqKDtEdnwWKVmuAAsYVQIxC6itShz/BZLC4hJuM=",
+        "lastModified": 1781179547,
+        "narHash": "sha256-b0p9BanfXa3J0IxZevEkDVDtkrHUiFm0wcWU7+/u7Ko=",
         "ref": "nix-split-modules",
-        "rev": "5cbddcf54beb2857ea591075d755a0b27842539b",
-        "revCount": 141,
+        "rev": "79c43da4caeaf0e030829063a8bbfb080d586d7f",
+        "revCount": 143,
         "type": "git",
         "url": "ssh://git@github.com/metafori-studio/infra.git"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -43,17 +43,16 @@
       },
       "locked": {
         "dir": "nix",
-        "lastModified": 1781179547,
-        "narHash": "sha256-b0p9BanfXa3J0IxZevEkDVDtkrHUiFm0wcWU7+/u7Ko=",
-        "ref": "nix-split-modules",
-        "rev": "79c43da4caeaf0e030829063a8bbfb080d586d7f",
-        "revCount": 143,
+        "lastModified": 1781182886,
+        "narHash": "sha256-Z/5cBz1QnVIPSl+DGtznd48R+7WqeebfR44pdE8WiqU=",
+        "ref": "refs/heads/main",
+        "rev": "d6b52b719c7acdafc33f9d621302bb9a30be4526",
+        "revCount": 144,
         "type": "git",
         "url": "ssh://git@github.com/metafori-studio/infra.git"
       },
       "original": {
         "dir": "nix",
-        "ref": "nix-split-modules",
         "type": "git",
         "url": "ssh://git@github.com/metafori-studio/infra.git"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,8 @@
       in {
         devShells.default = pkgs.mkShell (metafori.devshell {
           inherit pkgs metafori;
-          enablePostgres = true;
+          enablePhp = false;
+          enablePostgres = false;
           enableValkey = false;
           enableOpensearch = false;
           enableMonitoring = false;

--- a/flake.nix
+++ b/flake.nix
@@ -2,37 +2,31 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    infra.url = "git+ssh://git@github.com/metafori-studio/infra.git?dir=nix";
+    infra.url =
+      "git+ssh://git@github.com/metafori-studio/infra.git?dir=nix&ref=nix-split-modules";
   };
 
-  outputs =
-    {
-      nixpkgs,
-      flake-utils,
-      infra,
-      ...
-    }:
-    flake-utils.lib.eachDefaultSystem (
-      system:
+  outputs = { nixpkgs, flake-utils, infra, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
         metafori = infra.lib;
-      in
-      {
-        devShells.default = pkgs.mkShell (
-          metafori.devshell {
-            inherit pkgs metafori;
-            enableDatabases = true;
-            enableMonitoring = true;
-            enableStorage = true;
-            enableXdebug = false;
-            configOverrides = {
-              postgresDb = "collection_toolbox_backend";
-            };
-          }
-        );
+      in {
+        devShells.default = pkgs.mkShell (metafori.devshell {
+          inherit pkgs metafori;
+          enablePostgres = true;
+          enableValkey = false;
+          enableOpensearch = false;
+          enableMonitoring = false;
+          enableStorage = false;
+          enableXdebug = false;
+          configOverrides = {
+            projectName = "collection-toolbox-backend";
+            postgres.db = "collection_toolbox_backend";
+            s3Bucket = "collection-toolbox-assets";
+          };
+        });
 
         packages.default = metafori.php { inherit pkgs; };
-      }
-    );
+      });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     infra.url =
-      "git+ssh://git@github.com/metafori-studio/infra.git?dir=nix&ref=nix-split-modules";
+      "git+ssh://git@github.com/metafori-studio/infra.git?dir=nix";
   };
 
   outputs = { nixpkgs, flake-utils, infra, ... }:
@@ -14,12 +14,12 @@
       in {
         devShells.default = pkgs.mkShell (metafori.devshell {
           inherit pkgs metafori;
-          enablePhp = false;
-          enablePostgres = false;
+          enablePhp = true;
+          enablePostgres = true;
           enableValkey = false;
           enableOpensearch = false;
           enableMonitoring = false;
-          enableStorage = false;
+          enableStorage = true;
           enableXdebug = false;
           configOverrides = {
             projectName = "collection-toolbox-backend";

--- a/justfile
+++ b/justfile
@@ -2,6 +2,9 @@ set shell := ["bash", "-c"]
 
 export PROJ_ROOT := env_var_or_default("PROJ_ROOT", `pwd`)
 
+default:
+    @just --list
+
 start-storage:
     @start-storage
 

--- a/justfile
+++ b/justfile
@@ -8,11 +8,23 @@ start-storage:
 stop-storage:
     @stop-storage
 
-start-databases:
-    @start-databases
+start-postgres:
+    @start-postgres
 
-stop-databases:
-    @stop-databases
+stop-postgres:
+    @stop-postgres
+
+start-valkey:
+    @start-valkey
+
+stop-valkey:
+    @stop-valkey
+
+start-opensearch:
+    @start-opensearch
+
+stop-opensearch:
+    @stop-opensearch
 
 start-monitoring:
     @start-monitoring


### PR DESCRIPTION
Right now we prefetch everything when starting a devshell and encapsulate opensearch, postgresql and valkey into `start-databases` block of services.

I have split `databases` into their own blocks (e.g. `start-valkey`) and fixed prefetching to only download packages that are explicitly enabled.

For example with php+pg+seaweedfs it amounts to ~700mb to previous 4GB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration with granular service controls (Postgres, Valkey, OpenSearch, Monitoring, Storage, Xdebug)
  * Refactored service management commands from bundled to individual start/stop recipes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->