### PR TITLE
feat(etno): add how_to_cite field to ItemResource response

### DIFF
--- a/app-modules/etno/src/Http/Resources/ItemResource.php
+++ b/app-modules/etno/src/Http/Resources/ItemResource.php
@@ -81,6 +81,12 @@ class ItemResource extends JsonResource
             'originators' => OriginatorResource::collection($this->whenLoaded('originators')),
             'keywords' => KeywordResource::collection($this->whenLoaded('keywords')),
             'research_collections' => ResearchCollectionResource::collection($this->whenLoaded('researchCollections')),
+            'how_to_cite' => $this->when(
+                $this->document->relationLoaded('institution')
+                    && $this->document->relationLoaded('authors')
+                    && $this->document->relationLoaded('originators'),
+                fn () => $this->document->how_to_cite
+            ),
             'document_id' => $this->document_id,
             /** @var MediaType|null */
             'media_type' => $this->whenLoaded('firstMedia', fn () => $this->firstMedia ? MediaType::tryFrom($this->firstMedia->collection_name) : null),

--- a/app-modules/etno/tests/Feature/Api/ItemShowTest.php
+++ b/app-modules/etno/tests/Feature/Api/ItemShowTest.php
@@ -81,6 +81,7 @@ it('can show a complete item with all relations', function () {
                 'publication_date_start',
                 'publication_date_end',
                 'publication_date_settings',
+                'how_to_cite',
                 'institution' => [
                     'id',
                     'name',
@@ -174,6 +175,7 @@ it('can show a complete item with all relations', function () {
                 'location_note' => $document->location_note,
                 'content_note' => $document->content_note,
                 'technical_note' => $document->technical_note,
+                'how_to_cite' => $document->how_to_cite,
                 'type' => $document->type?->value,
                 'extents' => collect($document->extents)->toArray(),
                 'language' => $document->language?->value,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API item responses now include a `how_to_cite` field when the required related information is available.
  * The field is omitted when that information is not loaded, keeping responses cleaner and more accurate.
* **Tests**
  * Updated item detail coverage to verify the new response field is present and matches the expected value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->