### PR TITLE
feat(etno): add frontend link actions to document and item edit pages

### DIFF
--- a/app-modules/etno/lang/en/ui.php
+++ b/app-modules/etno/lang/en/ui.php
@@ -88,6 +88,8 @@ return [
         'upload_media' => 'Upload Media',
         'create_from_files' => 'Create from files',
         'create_items' => 'Create Items',
+        'view_frontend' => 'View on web',
+        'unpublished' => 'Unpublished',
     ],
     'tooltips' => [
         'transcript_attached' => ':format Transcript Attached',

--- a/app-modules/etno/lang/sk/ui.php
+++ b/app-modules/etno/lang/sk/ui.php
@@ -88,6 +88,8 @@ return [
         'upload_media' => 'Nahrať médiá',
         'create_from_files' => 'Vytvoriť zo súborov',
         'create_items' => 'Vytvoriť položky',
+        'view_frontend' => 'Zobraziť na webe',
+        'unpublished' => 'Nepublikované',
     ],
     'tooltips' => [
         'transcript_attached' => 'Prepis vo formáte :format priložený',

--- a/app-modules/etno/src/Filament/Resources/Documents/Pages/EditDocument.php
+++ b/app-modules/etno/src/Filament/Resources/Documents/Pages/EditDocument.php
@@ -2,11 +2,14 @@
 
 namespace Metafori\Etno\Filament\Resources\Documents\Pages;
 
+use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\ForceDeleteAction;
 use Filament\Actions\RestoreAction;
 use Filament\Resources\Pages\EditRecord;
+use Filament\Support\Icons\Heroicon;
 use Metafori\Etno\Filament\Resources\Documents\DocumentResource;
+use Metafori\Etno\Support\Frontend;
 
 class EditDocument extends EditRecord
 {
@@ -15,6 +18,19 @@ class EditDocument extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
+            Action::make('view_frontend')
+                ->label(__('etno::ui.actions.view_frontend'))
+                ->icon(Heroicon::OutlinedArrowTopRightOnSquare)
+                ->url(fn (): string => Frontend::documentUrl($this->record->id))
+                ->openUrlInNewTab()
+                ->color('gray')
+                ->visible(fn (): bool => $this->record->isPublished()),
+            Action::make('unpublished')
+                ->label(__('etno::ui.actions.unpublished'))
+                ->color('gray')
+                ->disabled()
+                ->link()
+                ->visible(fn (): bool => ! $this->record->isPublished()),
             $this->getSaveFormAction()
                 ->formId('form'),
             DeleteAction::make(),

--- a/app-modules/etno/src/Filament/Resources/Items/Pages/EditItem.php
+++ b/app-modules/etno/src/Filament/Resources/Items/Pages/EditItem.php
@@ -3,11 +3,14 @@
 namespace Metafori\Etno\Filament\Resources\Items\Pages;
 
 use Filament\Actions;
+use Filament\Actions\Action;
 use Filament\Resources\Pages\EditRecord;
+use Filament\Support\Icons\Heroicon;
 use Metafori\Etno\Filament\Actions\Items\UploadMediaAction;
 use Metafori\Etno\Filament\Concerns\WithDocument;
 use Metafori\Etno\Filament\Contracts\HasDocument;
 use Metafori\Etno\Filament\Resources\Items\ItemResource;
+use Metafori\Etno\Support\Frontend;
 
 class EditItem extends EditRecord implements HasDocument
 {
@@ -18,6 +21,19 @@ class EditItem extends EditRecord implements HasDocument
     protected function getHeaderActions(): array
     {
         return [
+            Action::make('view_frontend')
+                ->label(__('etno::ui.actions.view_frontend'))
+                ->icon(Heroicon::OutlinedArrowTopRightOnSquare)
+                ->url(fn (): string => Frontend::itemUrl($this->record->identifier))
+                ->openUrlInNewTab()
+                ->color('gray')
+                ->visible(fn (): bool => $this->record->isPublished()),
+            Action::make('unpublished')
+                ->label(__('etno::ui.actions.unpublished'))
+                ->color('gray')
+                ->disabled()
+                ->link()
+                ->visible(fn (): bool => ! $this->record->isPublished()),
             UploadMediaAction::make('upload_media'),
             Actions\DeleteAction::make(),
             Actions\ForceDeleteAction::make(),

--- a/app-modules/etno/src/Models/Document.php
+++ b/app-modules/etno/src/Models/Document.php
@@ -115,6 +115,14 @@ class Document extends Model implements Stringable
         $query->whereIn('access_rights', AccessRights::published());
     }
 
+    public function isPublished(): bool
+    {
+        return \in_array(
+            $this->access_rights,
+            AccessRights::published()
+        );
+    }
+
     public static function relations(): array
     {
         return [

--- a/app-modules/etno/src/Providers/EtnoServiceProvider.php
+++ b/app-modules/etno/src/Providers/EtnoServiceProvider.php
@@ -33,6 +33,11 @@ class EtnoServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        config([
+            'frontend.routes.document' => '/{locale}/documents/{id}',
+            'frontend.routes.item' => '/{locale}/items/{id}',
+        ]);
+
         $this->loadTranslationsFrom(__DIR__.'/../../lang', 'etno');
 
         Item::observe(ItemObserver::class);

--- a/app-modules/etno/src/Support/Frontend.php
+++ b/app-modules/etno/src/Support/Frontend.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Metafori\Etno\Support;
+
+use Metafori\Core\Support\Frontend as CoreFrontend;
+
+class Frontend extends CoreFrontend
+{
+    public static function documentUrl(string $id, ?string $locale = null): string
+    {
+        return (new self)->route('document', [
+            'id' => $id,
+            'locale' => $locale ?? app()->getLocale(),
+        ]);
+    }
+
+    public static function itemUrl(string $id, ?string $locale = null): string
+    {
+        return (new self)->route('item', [
+            'id' => $id,
+            'locale' => $locale ?? app()->getLocale(),
+        ]);
+    }
+}

--- a/app-modules/etno/tests/Feature/Filament/DocumentResourceTest.php
+++ b/app-modules/etno/tests/Feature/Filament/DocumentResourceTest.php
@@ -15,6 +15,7 @@ use Metafori\Etno\Enums\ProductionMethod;
 use Metafori\Etno\Filament\Resources\Documents\Pages\EditDocument;
 use Metafori\Etno\Models\Document;
 use Metafori\Etno\Models\Project;
+use Metafori\Etno\Support\Frontend;
 
 use function Pest\Livewire\livewire;
 
@@ -110,3 +111,29 @@ dataset('document_inputs_relational_belongsto', [
     'institution_id' => ['institution_id', fn () => Organization::factory()->create()->id],
     'project_id' => ['project_id', fn () => Project::factory()->create()->id],
 ]);
+
+it('shows view_frontend action and hides unpublished text when document is published', function () {
+    $user = User::factory()->admin()->create();
+    $this->actingAs($user);
+
+    $document = Document::factory()->published(true)->create();
+
+    $expectedUrl = Frontend::documentUrl($document->id);
+
+    livewire(EditDocument::class, ['record' => $document->id])
+        ->assertActionVisible('view_frontend')
+        ->assertActionHasUrl('view_frontend', $expectedUrl)
+        ->assertActionShouldOpenUrlInNewTab('view_frontend')
+        ->assertActionHidden('unpublished');
+});
+
+it('shows unpublished text and hides view_frontend action when document is unpublished', function () {
+    $user = User::factory()->admin()->create();
+    $this->actingAs($user);
+
+    $document = Document::factory()->published(false)->create();
+
+    livewire(EditDocument::class, ['record' => $document->id])
+        ->assertActionVisible('unpublished')
+        ->assertActionHidden('view_frontend');
+});

--- a/app-modules/etno/tests/Feature/Filament/Resources/Items/Pages/EditItemTest.php
+++ b/app-modules/etno/tests/Feature/Filament/Resources/Items/Pages/EditItemTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Metafori\Etno\Tests\Feature\Filament\Resources\Items\Pages;
+
+use Metafori\Core\Models\User;
+use Metafori\Etno\Filament\Resources\Items\Pages\EditItem;
+use Metafori\Etno\Models\Item;
+use Metafori\Etno\Support\Frontend;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    actingAs(User::factory()->admin()->create());
+});
+
+it('shows view_frontend action and hides unpublished text when item is published', function () {
+    $item = Item::factory()->published(true)->create();
+
+    $expectedUrl = Frontend::itemUrl($item->identifier);
+
+    livewire(EditItem::class, [
+        'parentRecord' => $item->document,
+        'record' => $item->id,
+    ])
+        ->assertActionVisible('view_frontend')
+        ->assertActionHasUrl('view_frontend', $expectedUrl)
+        ->assertActionShouldOpenUrlInNewTab('view_frontend')
+        ->assertActionHidden('unpublished');
+});
+
+it('shows unpublished text and hides view_frontend action when item is unpublished', function () {
+    $item = Item::factory()->published(false)->create();
+
+    livewire(EditItem::class, [
+        'parentRecord' => $item->document,
+        'record' => $item->id,
+    ])
+        ->assertActionVisible('unpublished')
+        ->assertActionHidden('view_frontend');
+});

--- a/app-modules/etno/tests/Feature/Support/FrontendTest.php
+++ b/app-modules/etno/tests/Feature/Support/FrontendTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Metafori\Etno\Support\Frontend;
+
+it('generates document detail url with locale and id', function () {
+    config()->set('frontend.url', 'http://localhost:3000');
+
+    $url = Frontend::documentUrl('AD000001', 'sk');
+
+    expect($url)->toBe('http://localhost:3000/sk/documents/AD000001');
+});
+
+it('generates document detail url using default locale if not specified', function () {
+    config()->set('frontend.url', 'http://localhost:3000');
+    app()->setLocale('en');
+
+    $url = Frontend::documentUrl('AD000002');
+
+    expect($url)->toBe('http://localhost:3000/en/documents/AD000002');
+});
+
+it('generates item detail url with locale and id', function () {
+    config()->set('frontend.url', 'http://localhost:3000');
+
+    $url = Frontend::itemUrl('AD000001:a', 'sk');
+
+    expect($url)->toBe('http://localhost:3000/sk/items/AD000001%3Aa');
+});
+
+it('generates item detail url using default locale if not specified', function () {
+    config()->set('frontend.url', 'http://localhost:3000');
+    app()->setLocale('en');
+
+    $url = Frontend::itemUrl('AD000001:b');
+
+    expect($url)->toBe('http://localhost:3000/en/items/AD000001%3Ab');
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added frontend links for documents and items, plus helper methods to generate those URLs.
  * Added new document and item actions in the editor to open the public page in a new tab.
  * Added status-aware labels for published and unpublished content.

* **Bug Fixes**
  * Improved visibility of editor actions so users only see the relevant option based on publication status.

* **Tests**
  * Added coverage for URL generation and action visibility on document and item edit screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->