### PR TITLE
[OGL-1636] feat(archeo): add console command to import and assign PDFs to activities based on CVS number

### DIFF
--- a/app-modules/archeo/src/Console/Commands/ImportExternalPdfsCommand.php
+++ b/app-modules/archeo/src/Console/Commands/ImportExternalPdfsCommand.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Metafori\Archeo\Console\Commands;
+
+use Illuminate\Console\Command;
+use Metafori\Archeo\Models\Activity;
+
+class ImportExternalPdfsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'archeo:import-pdfs
+                            {path : The path to the directory or single PDF file}
+                            {--delete-sources : Delete the source PDFs inside the container after successful assignment}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Import and assign external PDFs to activities by CVS number';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $path = $this->argument('path');
+        $deleteSources = $this->option('delete-sources');
+
+        if (! file_exists($path) && file_exists(storage_path($path))) {
+            $path = storage_path($path);
+        }
+
+        if (! file_exists($path)) {
+            $this->error("The path [{$path}] does not exist.");
+
+            return 1;
+        }
+
+        $files = [];
+        if (is_dir($path)) {
+            $files = glob(rtrim($path, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'*.{pdf,PDF}', GLOB_BRACE);
+        } elseif (is_file($path)) {
+            if (strtolower(pathinfo($path, PATHINFO_EXTENSION)) === 'pdf') {
+                $files = [$path];
+            } else {
+                $this->error("The file [{$path}] is not a PDF.");
+
+                return 1;
+            }
+        }
+
+        if (empty($files) || $files === false) {
+            $this->warn('No PDF files found to process.');
+
+            return 0;
+        }
+
+        $this->info('Found '.count($files).' PDF file(s) to process.');
+
+        $successCount = 0;
+        $failedCount = 0;
+
+        foreach ($files as $file) {
+            $filename = pathinfo($file, PATHINFO_FILENAME);
+            $cvsNumber = $this->extractCvsNumber($filename);
+
+            if ($cvsNumber === null) {
+                $this->warn("Could not extract CVS number from filename: {$filename}");
+                $failedCount++;
+
+                continue;
+            }
+
+            $activities = Activity::where('cvs_number', $cvsNumber)->get();
+
+            if ($activities->isEmpty()) {
+                $this->warn("No activities found with CVS number: {$cvsNumber} (File: {$filename})");
+                $failedCount++;
+
+                continue;
+            }
+
+            $this->info("Assigning {$filename}.pdf to ".$activities->count()." activity/activities matching CVS: {$cvsNumber}");
+
+            $assigned = false;
+            foreach ($activities as $activity) {
+                try {
+                    $activity->addMedia($file)
+                        ->usingName($filename)
+                        ->usingFileName(basename($file))
+                        ->preservingOriginal()
+                        ->toMediaCollection('pdfs', config('archeo.pdfs_disk', 'public'));
+                    $assigned = true;
+                } catch (\Exception $e) {
+                    $this->error("Failed to assign {$filename}.pdf to Activity {$activity->activity_number}: {$e->getMessage()}");
+                }
+            }
+
+            if ($assigned) {
+                $successCount++;
+                if ($deleteSources) {
+                    @unlink($file);
+                }
+            } else {
+                $failedCount++;
+            }
+        }
+
+        $this->info("Import completed. Successfully processed {$successCount} files. Failed/skipped {$failedCount} files.");
+
+        return 0;
+    }
+
+    /**
+     * Extract the CVS number from a filename.
+     */
+    private function extractCvsNumber(string $filename): ?int
+    {
+        if (preg_match('/^(\d+)/', $filename, $matches)) {
+            return (int) $matches[1];
+        }
+
+        return null;
+    }
+}

--- a/app-modules/archeo/src/Providers/ArcheoServiceProvider.php
+++ b/app-modules/archeo/src/Providers/ArcheoServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 use Metafori\Archeo\ArcheoPlugin;
+use Metafori\Archeo\Console\Commands\ImportExternalPdfsCommand;
 use Metafori\Archeo\Listeners\CompressPdfOnUploadListener;
 use Metafori\Archeo\Models\Activity;
 use Metafori\Archeo\Models\ActivityAssignment;
@@ -47,5 +48,11 @@ class ArcheoServiceProvider extends ServiceProvider
 
         $this->loadMigrationsFrom(__DIR__.'/../../database/migrations');
         $this->loadRoutesFrom(__DIR__.'/../../routes/api.php');
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                ImportExternalPdfsCommand::class,
+            ]);
+        }
     }
 }

--- a/app-modules/archeo/tests/Feature/Console/Commands/ImportExternalPdfsCommandTest.php
+++ b/app-modules/archeo/tests/Feature/Console/Commands/ImportExternalPdfsCommandTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Metafori\Archeo\Models\Activity;
+
+beforeEach(function () {
+    Storage::fake();
+    Storage::fake('public');
+    Queue::fake();
+});
+
+it('can import and assign a PDF named with exact CVS number to matching activity', function () {
+    $activity = Activity::factory()->create(['cvs_number' => 123]);
+
+    Storage::put('import_test/123.pdf', '%PDF-1.4 fake content');
+    $pdfPath = Storage::path('import_test/123.pdf');
+
+    $this->artisan('archeo:import-pdfs', [
+        'path' => $pdfPath,
+    ])
+        ->expectsOutputToContain('Assigning 123.pdf to 1 activity/activities matching CVS: 123')
+        ->assertExitCode(0);
+
+    expect($activity->fresh()->hasMedia('pdfs'))->toBeTrue();
+    expect($activity->fresh()->getFirstMedia('pdfs')->file_name)->toBe('123.pdf');
+    expect(Storage::exists('import_test/123.pdf'))->toBeTrue(); // defaults to preserving original file
+});
+
+it('can extract CVS number from various file names', function () {
+    $activity1 = Activity::factory()->create(['cvs_number' => 456]);
+    $activity2 = Activity::factory()->create(['cvs_number' => 789]);
+    $activity3 = Activity::factory()->create(['cvs_number' => 999]);
+    $activity4 = Activity::factory()->create(['cvs_number' => 20853]);
+
+    Storage::put('import_test_various/456_file.pdf', '%PDF-1.4 fake content');
+    Storage::put('import_test_various/789-file.pdf', '%PDF-1.4 fake content');
+    Storage::put('import_test_various/999.pdf', '%PDF-1.4 fake content');
+    Storage::put('import_test_various/20853_23ns.pdf', '%PDF-1.4 fake content');
+
+    $tempDir = Storage::path('import_test_various');
+
+    $this->artisan('archeo:import-pdfs', [
+        'path' => $tempDir,
+    ])
+        ->expectsOutputToContain('Assigning 456_file.pdf to 1 activity/activities matching CVS: 456')
+        ->expectsOutputToContain('Assigning 789-file.pdf to 1 activity/activities matching CVS: 789')
+        ->expectsOutputToContain('Assigning 999.pdf to 1 activity/activities matching CVS: 999')
+        ->expectsOutputToContain('Assigning 20853_23ns.pdf to 1 activity/activities matching CVS: 20853')
+        ->assertExitCode(0);
+
+    expect($activity1->fresh()->hasMedia('pdfs'))->toBeTrue();
+    expect($activity2->fresh()->hasMedia('pdfs'))->toBeTrue();
+    expect($activity3->fresh()->hasMedia('pdfs'))->toBeTrue();
+    expect($activity4->fresh()->hasMedia('pdfs'))->toBeTrue();
+});
+
+it('can assign a PDF to multiple matching activities sharing the same CVS number', function () {
+    $activity1 = Activity::factory()->create(['cvs_number' => 555]);
+    $activity2 = Activity::factory()->create(['cvs_number' => 555]);
+
+    Storage::put('import_test_multiple/555.pdf', '%PDF-1.4 fake content');
+    $pdfPath = Storage::path('import_test_multiple/555.pdf');
+
+    $this->artisan('archeo:import-pdfs', [
+        'path' => $pdfPath,
+    ])
+        ->expectsOutputToContain('Assigning 555.pdf to 2 activity/activities matching CVS: 555')
+        ->assertExitCode(0);
+
+    expect($activity1->fresh()->hasMedia('pdfs'))->toBeTrue();
+    expect($activity2->fresh()->hasMedia('pdfs'))->toBeTrue();
+});
+
+it('deletes the source file after successful import when --delete-sources is provided', function () {
+    $activity = Activity::factory()->create(['cvs_number' => 888]);
+
+    Storage::put('import_test_delete/888.pdf', '%PDF-1.4 fake content');
+    $pdfPath = Storage::path('import_test_delete/888.pdf');
+
+    expect(Storage::exists('import_test_delete/888.pdf'))->toBeTrue();
+
+    $this->artisan('archeo:import-pdfs', [
+        'path' => $pdfPath,
+        '--delete-sources' => true,
+    ])
+        ->assertExitCode(0);
+
+    expect($activity->fresh()->hasMedia('pdfs'))->toBeTrue();
+    expect(Storage::exists('import_test_delete/888.pdf'))->toBeFalse(); // deleted
+});
+
+it('skips and warns when no CVS number can be extracted', function () {
+    Storage::put('import_test_no_cvs/no_digits_here.pdf', '%PDF-1.4 fake content');
+    $pdfPath = Storage::path('import_test_no_cvs/no_digits_here.pdf');
+
+    $this->artisan('archeo:import-pdfs', [
+        'path' => $pdfPath,
+    ])
+        ->expectsOutputToContain('Could not extract CVS number from filename: no_digits_here')
+        ->assertExitCode(0);
+});
+
+it('skips and warns when no activity matches the CVS number', function () {
+    Storage::put('import_test_no_match/99999.pdf', '%PDF-1.4 fake content');
+    $pdfPath = Storage::path('import_test_no_match/99999.pdf');
+
+    $this->artisan('archeo:import-pdfs', [
+        'path' => $pdfPath,
+    ])
+        ->expectsOutputToContain('No activities found with CVS number: 99999 (File: 99999)')
+        ->assertExitCode(0);
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a console command to import external PDFs from a directory or individual file.
  * Automatically matches PDFs to activities using the CVS number in each filename.
  * Supports importing files for multiple matching activities.
  * Added an option to delete source PDFs after successful assignment.
  * Provides progress, warning, error, and completion summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->