### PR TITLE
fix(etno): resolve media_type resolution logic in ItemResource

### DIFF
--- a/app-modules/etno/src/Http/Resources/ItemResource.php
+++ b/app-modules/etno/src/Http/Resources/ItemResource.php
@@ -91,9 +91,11 @@ class ItemResource extends JsonResource
             /** @var MediaType|null */
             'media_type' => $this->whenLoaded(
                 'firstMedia',
-                fn () => $this->firstMedia
-                    ? $this->firstMedia->getType()
-                    : $this->whenLoaded('media', fn () => $this->media->first()?->getType())
+                fn () => $this->firstMedia?->getType(),
+                fn () => $this->whenLoaded(
+                    'media',
+                    fn () => $this->media->first()?->getType()
+                )
             ),
             'first_media' => $this->whenLoaded('firstMedia', fn () => $this->when(
                 Gate::allows('viewMedia', $this->resource),

--- a/app-modules/etno/tests/Feature/Api/ItemShowTest.php
+++ b/app-modules/etno/tests/Feature/Api/ItemShowTest.php
@@ -4,6 +4,7 @@ use Metafori\Core\Enums\Language;
 use Metafori\Core\Models\MunicipalityPart;
 use Metafori\Core\Models\User;
 use Metafori\Etno\Enums\AccessRights;
+use Metafori\Etno\Enums\MediaType;
 use Metafori\Etno\Enums\ProductionMethod;
 use Metafori\Etno\Models\Document;
 use Metafori\Etno\Models\Item;
@@ -53,6 +54,7 @@ it('can show a complete item with all relations', function () {
                 'content_note',
                 'technical_note',
                 'type',
+                'media_type',
                 'media' => [
                     'documents' => [
                         '*' => [
@@ -178,6 +180,7 @@ it('can show a complete item with all relations', function () {
                 'technical_note' => $document->technical_note,
                 'how_to_cite' => $document->how_to_cite,
                 'type' => $document->type?->value,
+                'media_type' => MediaType::Document->value,
                 'extents' => collect($document->extents)->toArray(),
                 'languages' => collect($document->languages)
                     ->map(fn (Language $lang) => $lang->value)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of the media type shown for items, including fallback handling when media details are loaded differently.
  * API responses now consistently include the item’s media type.

* **Tests**
  * Added coverage verifying that document items return the correct media type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->