### PR TITLE
[OGL-1633] refactor(etno): flatten locality hierarchy

### DIFF
--- a/app-modules/core/src/Http/Resources/CountryResource.php
+++ b/app-modules/core/src/Http/Resources/CountryResource.php
@@ -22,6 +22,7 @@ class CountryResource extends JsonResource
             'id' => $this->id,
             /** @var string */
             'name' => $this->name,
+            'type' => $this->getMorphClass(),
         ];
     }
 }

--- a/app-modules/core/src/Http/Resources/DistrictResource.php
+++ b/app-modules/core/src/Http/Resources/DistrictResource.php
@@ -22,7 +22,7 @@ class DistrictResource extends JsonResource
             'id' => $this->id,
             /** @var string */
             'name' => $this->name,
-            'region' => new RegionResource($this->whenLoaded('region')),
+            'type' => $this->getMorphClass(),
         ];
     }
 }

--- a/app-modules/core/src/Http/Resources/LocationResource.php
+++ b/app-modules/core/src/Http/Resources/LocationResource.php
@@ -22,10 +22,7 @@ class LocationResource extends JsonResource
             'id' => $this->id,
             /** @var string */
             'name' => $this->name,
-            /** @var CountryResource|RegionResource|DistrictResource|MunicipalityResource|MunicipalityPartResource */
-            'parent' => $this->whenLoaded('parent', function () {
-                return $this->parent->toResource();
-            }),
+            'type' => $this->getMorphClass(),
         ];
     }
 }

--- a/app-modules/core/src/Http/Resources/MunicipalityPartResource.php
+++ b/app-modules/core/src/Http/Resources/MunicipalityPartResource.php
@@ -22,7 +22,7 @@ class MunicipalityPartResource extends JsonResource
             'id' => $this->id,
             /** @var string */
             'name' => $this->name,
-            'municipality' => new MunicipalityResource($this->whenLoaded('municipality')),
+            'type' => $this->getMorphClass(),
         ];
     }
 }

--- a/app-modules/core/src/Http/Resources/MunicipalityResource.php
+++ b/app-modules/core/src/Http/Resources/MunicipalityResource.php
@@ -22,7 +22,7 @@ class MunicipalityResource extends JsonResource
             'id' => $this->id,
             /** @var string */
             'name' => $this->name,
-            'district' => new DistrictResource($this->whenLoaded('district')),
+            'type' => $this->getMorphClass(),
         ];
     }
 }

--- a/app-modules/core/src/Http/Resources/RegionResource.php
+++ b/app-modules/core/src/Http/Resources/RegionResource.php
@@ -22,7 +22,7 @@ class RegionResource extends JsonResource
             'id' => $this->id,
             /** @var string */
             'name' => $this->name,
-            'country' => new CountryResource($this->whenLoaded('country')),
+            'type' => $this->getMorphClass(),
         ];
     }
 }

--- a/app-modules/etno/src/Http/Resources/Concerns/ResolvesLocality.php
+++ b/app-modules/etno/src/Http/Resources/Concerns/ResolvesLocality.php
@@ -18,15 +18,34 @@ use Metafori\Core\Models\Region;
 
 trait ResolvesLocality
 {
-    protected function resolveLocality(Locality $locality): CountryResource|RegionResource|DistrictResource|MunicipalityResource|MunicipalityPartResource|LocationResource
+    /**
+     * @return array<int, CountryResource|RegionResource|DistrictResource|MunicipalityResource|MunicipalityPartResource|LocationResource>
+     */
+    protected function resolveLocality(Locality $locality): array
     {
-        return match (true) {
-            $locality instanceof Country => new CountryResource($locality),
-            $locality instanceof Region => new RegionResource($locality),
-            $locality instanceof District => new DistrictResource($locality),
-            $locality instanceof Municipality => new MunicipalityResource($locality),
-            $locality instanceof MunicipalityPart => new MunicipalityPartResource($locality),
-            $locality instanceof Location => new LocationResource($locality),
-        };
+        $localities = [];
+        $current = $locality;
+
+        while ($current) {
+            $localities[] = match (true) {
+                $current instanceof Country => new CountryResource($current),
+                $current instanceof Region => new RegionResource($current),
+                $current instanceof District => new DistrictResource($current),
+                $current instanceof Municipality => new MunicipalityResource($current),
+                $current instanceof MunicipalityPart => new MunicipalityPartResource($current),
+                $current instanceof Location => new LocationResource($current),
+            };
+
+            $current = match (true) {
+                $current instanceof MunicipalityPart => $current->relationLoaded('municipality') ? $current->municipality : null,
+                $current instanceof Municipality => $current->relationLoaded('district') ? $current->district : null,
+                $current instanceof District => $current->relationLoaded('region') ? $current->region : null,
+                $current instanceof Region => $current->relationLoaded('country') ? $current->country : null,
+                $current instanceof Location => $current->relationLoaded('parent') ? $current->parent : null,
+                default => null,
+            };
+        }
+
+        return $localities;
     }
 }

--- a/app-modules/etno/tests/Feature/Api/DocumentShowTest.php
+++ b/app-modules/etno/tests/Feature/Api/DocumentShowTest.php
@@ -67,23 +67,10 @@ it('can show a complete document with all relations', function () {
                     'title',
                 ],
                 'locality' => [
-                    'id',
-                    'name',
-                    'municipality' => [
+                    '*' => [
                         'id',
                         'name',
-                        'district' => [
-                            'id',
-                            'name',
-                            'region' => [
-                                'id',
-                                'name',
-                                'country' => [
-                                    'id',
-                                    'name',
-                                ],
-                            ],
-                        ],
+                        'type',
                     ],
                 ],
                 'authors' => [
@@ -172,8 +159,31 @@ it('can show a complete document with all relations', function () {
                     'title' => $document->project->title,
                 ],
                 'locality' => [
-                    'id' => $document->locality->id,
-                    'name' => $document->locality->name,
+                    [
+                        'id' => $document->locality->id,
+                        'name' => $document->locality->name,
+                        'type' => 'municipality_part',
+                    ],
+                    [
+                        'id' => $document->locality->municipality->id,
+                        'name' => $document->locality->municipality->name,
+                        'type' => 'municipality',
+                    ],
+                    [
+                        'id' => $document->locality->municipality->district->id,
+                        'name' => $document->locality->municipality->district->name,
+                        'type' => 'district',
+                    ],
+                    [
+                        'id' => $document->locality->municipality->district->region->id,
+                        'name' => $document->locality->municipality->district->region->name,
+                        'type' => 'region',
+                    ],
+                    [
+                        'id' => $document->locality->municipality->district->region->country->id,
+                        'name' => $document->locality->municipality->district->region->country->name,
+                        'type' => 'country',
+                    ],
                 ],
                 'originators' => $document->originators->map(fn ($originator) => [
                     'id' => $originator->id,

--- a/app-modules/etno/tests/Feature/Api/ItemIndexTest.php
+++ b/app-modules/etno/tests/Feature/Api/ItemIndexTest.php
@@ -33,6 +33,7 @@ uses(RefreshIndices::class);
 it('can list items', function () {
     Document::factory()
         ->published()
+        ->for(Location::factory(), 'locality')
         ->hasItems(2)
         ->hasAuthors(2)
         ->hasResearchers(2)
@@ -77,8 +78,11 @@ it('can list items', function () {
                         ],
                     ],
                     'locality' => [
-                        'id',
-                        'name',
+                        '*' => [
+                            'id',
+                            'name',
+                            'type',
+                        ],
                     ],
                     'media_type',
                 ],

--- a/app-modules/etno/tests/Feature/Api/ItemShowTest.php
+++ b/app-modules/etno/tests/Feature/Api/ItemShowTest.php
@@ -95,23 +95,10 @@ it('can show a complete item with all relations', function () {
                     'title',
                 ],
                 'locality' => [
-                    'id',
-                    'name',
-                    'municipality' => [
+                    '*' => [
                         'id',
                         'name',
-                        'district' => [
-                            'id',
-                            'name',
-                            'region' => [
-                                'id',
-                                'name',
-                                'country' => [
-                                    'id',
-                                    'name',
-                                ],
-                            ],
-                        ],
+                        'type',
                     ],
                 ],
                 'authors' => [
@@ -217,8 +204,31 @@ it('can show a complete item with all relations', function () {
                     'title' => $document->project->title,
                 ],
                 'locality' => [
-                    'id' => $document->locality->id,
-                    'name' => $document->locality->name,
+                    [
+                        'id' => $document->locality->id,
+                        'name' => $document->locality->name,
+                        'type' => 'municipality_part',
+                    ],
+                    [
+                        'id' => $document->locality->municipality->id,
+                        'name' => $document->locality->municipality->name,
+                        'type' => 'municipality',
+                    ],
+                    [
+                        'id' => $document->locality->municipality->district->id,
+                        'name' => $document->locality->municipality->district->name,
+                        'type' => 'district',
+                    ],
+                    [
+                        'id' => $document->locality->municipality->district->region->id,
+                        'name' => $document->locality->municipality->district->region->name,
+                        'type' => 'region',
+                    ],
+                    [
+                        'id' => $document->locality->municipality->district->region->country->id,
+                        'name' => $document->locality->municipality->district->region->country->name,
+                        'type' => 'country',
+                    ],
                 ],
                 'authors' => $document->authors->map(fn ($author) => [
                     'id' => $author->id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Locality data in API responses now includes an ordered hierarchy, from the specific locality through its parent regions and country.
  * Each locality entry now identifies its `id`, `name`, and `type`.
* **API Improvements**
  * Replaced deeply nested locality relationships with a consistent array-based representation.
  * Updated item and document responses to use the new locality format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->